### PR TITLE
Add T_flange and T_base aux transforms to Robot

### DIFF
--- a/src/general_robotics_toolbox/general_robotics_toolbox_invkin.py
+++ b/src/general_robotics_toolbox/general_robotics_toolbox_invkin.py
@@ -137,13 +137,10 @@ def robot6_sphericalwrist_invkin(robot, desired_pose, last_joints = None):
     """
     
     
-    
-    R06 = desired_pose.R
-    p0T = desired_pose.p
-    
-    if robot.R_tool is not None and robot.p_tool is not None:
-        R06 = R06.dot(np.transpose(robot.R_tool))
-        p0T = p0T - R06.dot(robot.p_tool)
+    desired_pose2 = rox.unapply_robot_aux_transforms(robot, desired_pose)
+
+    R06 = desired_pose2.R
+    p0T = desired_pose2.p
     
     H = robot.H
     P = robot.P
@@ -247,12 +244,10 @@ def ur_invkin(robot, desired_pose, last_joints = None):
              is specified, the first entry is the closest configuration to last_joints.    
     """
     
-    R06 = desired_pose.R
-    p0T = desired_pose.p
-    
-    if robot.R_tool is not None and robot.p_tool is not None:
-        R06 = np.matmul(R06,np.transpose(robot.R_tool))
-        p0T = p0T - np.matmul(R06,robot.p_tool)
+    desired_pose2 = rox.unapply_robot_aux_transforms(robot, desired_pose)
+
+    R06 = desired_pose2.R
+    p0T = desired_pose2.p
     
     H = robot.H
     P = robot.P


### PR DESCRIPTION
Add `T_flange` and `T_base` optional fields to the Robot class that contain the transform from the world origin to the base of the robot, and a `T_flange` transform between the end of the `P,H` kinematic chain and `R_tool,p_tool` tool transform. These transforms are important when the robot exists in a larger system with the robot not at the world origin, and when there is a separate tool attached to a flange that is not at identity with the end of the `P,H` chain.

Adds utility functions `apply_robot_aux_transforms()` and `unapply_robot_aux_transforms()` to assist with adding and removing auxiliary frames from a transform.

Updates kinematics functions to use aux frames.