### PR TITLE
Add Robot Raconteur info yaml file loaders and tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    install_requires=["numpy","urdf_parser_py"],
+    install_requires=["numpy","urdf_parser_py","pyyaml"],
     python_requires='>=2.7',
     tests_require=['pytest'],
     extras_require={

--- a/src/general_robotics_toolbox/robotraconteur.py
+++ b/src/general_robotics_toolbox/robotraconteur.py
@@ -158,8 +158,16 @@ def load_robot_info_yaml_to_robot(robot_info_file, chain_number=0):
             if tool_device_info is not None:
                 tip_link_name = _identifier_name(tool_device_info["device"])
 
+    T_base = None
+    robot_device_info = robot_yml.get("device_info", None)
+    if robot_device_info is not None:
+        robot_origin_pose = robot_device_info.get("device_origin_pose", None)
+        if robot_origin_pose is not None:
+            T_base = _to_transform(robot_origin_pose["pose"])
+
     rox_robot = rox.Robot(H, P, joint_type, joint_lower_limit, joint_upper_limit, joint_vel_limit,
-                          joint_acc_limit, None, r_tool, p_tool, joint_names, root_link_name, tip_link_name, T_flange=T_flange)
+                          joint_acc_limit, None, r_tool, p_tool, joint_names, root_link_name, tip_link_name,  
+                          T_flange=T_flange, T_base = T_base)
 
     return rox_robot
 

--- a/src/general_robotics_toolbox/robotraconteur.py
+++ b/src/general_robotics_toolbox/robotraconteur.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2022, Rensselaer Polytechnic Institute, Wason Technology LLC
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Rensselaer Polytechnic Institute, nor Wason
+#       Technology LLC, nor the names of its contributors may be used to
+#       endorse or promote products derived from this software without
+#       specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import absolute_import
+
+import yaml
+from . import general_robotics_toolbox as rox
+import numpy as np
+
+"""Provides utilities to read Robot Raconteur Yaml files containing robot and tool definition.
+   See RobotRaconteurCompanion.Util classes for conversions between Robot Raconteur and robotics toolbox types."""
+
+
+def _check_list(l, error_msg, expected_count=-1):
+    if l is None:
+        raise ValueError(error_msg)
+
+    if expected_count >= 0:
+        if len(l) != expected_count:
+            raise ValueError(error_msg)
+
+
+def _identifier_name(identifier):
+    if isinstance(identifier, str):
+        return identifier
+    else:
+        return identifier["name"]
+
+
+def _to_vec3(d):
+    return np.array([d["x"], d["y"], d["z"]], dtype=np.float64)
+
+
+def _to_qvec(d):
+    return np.array([d["w"], d["x"], d["y"], d["z"]], dtype=np.float64)
+
+
+def _to_transform(d):
+    if "orientation" in d:
+        q = _to_qvec(d["orientation"])
+        p = _to_vec3(d["position"])
+    else:
+        q = _to_qvec(d["rotation"])
+        p = _to_vec3(d["translation"])
+
+    return rox.Transform(rox.q2R(q), p)
+
+
+def load_robot_info_yaml_to_robot(robot_info_file, chain_number=0):
+    if isinstance(robot_info_file, dict):
+        robot_yml = robot_info_file
+    else:
+        robot_yml = yaml.safe_load(robot_info_file)
+    _check_list(
+        robot_yml["chains"], "could not find kinematic chain number " + str(chain_number))
+    if chain_number >= len(robot_yml["chains"]):
+        raise ValueError("invalid kinematic chain number " + str(chain_number))
+
+    chain = robot_yml["chains"][chain_number]
+    joint_count = len(chain["joint_numbers"])
+    for i in range(1, joint_count):
+        if chain["joint_numbers"][i-1] >= chain["joint_numbers"][i]:
+            raise ValueError(
+                "joint numbers must be increasing in chain number " + str(chain_number))
+
+        if chain["joint_numbers"][i] >= len(robot_yml["joint_info"]):
+            raise ValueError(
+                "joint number out of bounds in chain number " + str(chain_number))
+
+    _check_list(chain["H"], "invalid shape for H in chain number " +
+                str(chain_number), joint_count)
+    _check_list(chain["P"], "invalid shape for P in chain number " +
+                str(chain_number), joint_count + 1)
+
+    H = np.zeros((3, joint_count), dtype=np.float64)
+    for i in range(joint_count):
+        H[:, i] = _to_vec3(chain["H"][i])
+
+    P = np.zeros((3, joint_count + 1), dtype=np.float64)
+    for i in range(joint_count+1):
+        P[:, i] = _to_vec3(chain["P"][i])
+
+    joint_type = [0]*joint_count
+    joint_lower_limit = np.zeros((joint_count,), dtype=np.float64)
+    joint_upper_limit = np.zeros((joint_count,), dtype=np.float64)
+    joint_vel_limit = np.zeros((joint_count,), dtype=np.float64)
+    joint_acc_limit = np.zeros((joint_count,), dtype=np.float64)
+    joint_names = [None]*joint_count
+
+    for i in range(joint_count):
+        j = robot_yml["joint_info"][i]
+        if j["joint_type"] == "revolute":
+            # Revolute joint
+            joint_type[i] = 0
+        elif j["joint_type"] == "prismatic":
+            # Prismatic joint
+            joint_type[i] = 1
+        else:
+            raise ValueError("invalid joint type: " + str(j['joint_type']))
+
+        if j["joint_limits"] is None:
+            raise ValueError("joint_limits must not be null")
+        joint_lower_limit[i] = j["joint_limits"]["lower"]
+        joint_upper_limit[i] = j["joint_limits"]["upper"]
+        joint_vel_limit[i] = j["joint_limits"]["velocity"]
+        joint_acc_limit[i] = j["joint_limits"]["acceleration"]
+        if j["joint_identifier"] is not None:
+            joint_names[i] = _identifier_name(j["joint_identifier"])
+        else:
+            joint_names[i] = ""
+
+    root_link_name = None
+    if "link_identifiers" in chain and len(chain["link_identifiers"]) > 0 and chain["link_identifiers"][0] is not None:
+        root_link_name = _identifier_name(chain["link_identifiers"][0])
+
+    tip_link_name = None
+    if chain["flange_identifier"] is not None:
+        tip_link_name = _identifier_name(chain["flange_identifier"])
+
+    T_flange = _to_transform(chain["flange_pose"])
+
+    r_tool = None
+    p_tool = None
+
+    current_tool = chain.get("current_tool", None)
+    if current_tool is not None:
+        tcp = current_tool.get("tcp")
+        if tcp is not None:
+            T_tool = _to_transform(tcp)
+            r_tool = T_tool.R
+            p_tool = T_tool.p
+            tool_device_info = current_tool.get("device_info")
+            if tool_device_info is not None:
+                tip_link_name = _identifier_name(tool_device_info["device"])
+
+    rox_robot = rox.Robot(H, P, joint_type, joint_lower_limit, joint_upper_limit, joint_vel_limit,
+                          joint_acc_limit, None, r_tool, p_tool, joint_names, root_link_name, tip_link_name, T_flange=T_flange)
+
+    return rox_robot
+
+
+def load_robot_and_tool_info_yaml_to_robot(robot_info_file, tool_info_file, robot_chain_number=0):
+    robot = load_robot_info_yaml_to_robot(robot_info_file, robot_chain_number)
+    if isinstance(tool_info_file, dict):
+        tool_yml = tool_info_file
+    else:
+        tool_yml = yaml.safe_load(tool_info_file)
+
+    tcp = tool_yml["tcp"]
+
+    T_tool = _to_transform(tcp)
+    r_tool = T_tool.R
+    p_tool = T_tool.p
+    tool_device_info = tool_yml["device_info"]
+    tip_link_name = _identifier_name(tool_device_info["device"])
+
+    robot.R_tool = r_tool
+    robot.p_tool = p_tool
+    robot.tip_link_name = tip_link_name
+
+    return robot

--- a/test/abb_1200_5_90_robot_default_config.yml
+++ b/test/abb_1200_5_90_robot_default_config.yml
@@ -1,0 +1,153 @@
+device_info:
+  device:
+    name: abb_robot
+  manufacturer:
+    name: ABB
+    uuid: ee260e78-d731-415a-84ca-4b02c487410c
+  model:
+    name: ABB_1200_5_90
+    uuid: 9ad3c0ee-ec5e-4057-a297-d340e1484f01
+  user_description: ABB Robot
+  serial_number: 123456789
+  device_classes:
+    - class_identifier:
+        name: robot
+        uuid: 39b513e7-21b9-4b49-8654-7537473030eb
+      subclasses: 
+        - serial
+        - serial_six_axis        
+  implemented_types:
+    - com.robotraconteur.robotics.robot.Robot
+robot_type: serial
+robot_capabilities:
+- jog_command
+- trajectory_command
+- position_command
+chains:
+- kin_chain_identifier: robot_arm
+  H:
+  - x: 0.0
+    y: 0.0
+    z: 1.0
+  - x: 0.0
+    y: 1.0
+    z: 0.0
+  - x: 0.0
+    y: 1.0
+    z: 0.0
+  - x: 1.0
+    y: 0.0
+    z: 0.0
+  - x: 0.0
+    y: 1.0
+    z: 0.0
+  - x: 1.0
+    y: 0.0
+    z: 0.0
+  P:
+  - x: 0.0
+    y: 0.0
+    z: 0.3991
+  - x: 0.0
+    y: 0.0
+    z: 0.0
+  - x: 0.0
+    y: 0.0
+    z: 0.448
+  - x: 0.0
+    y: 0.0
+    z: 0.042
+  - x: 0.451
+    y: 0.0
+    z: 0.0
+  - x: 0.082
+    y: 0.0
+    z: 0.0
+  - x: 0.0
+    y: 0.0
+    z: 0.0
+  flange_identifier: tool0
+  flange_pose:
+    orientation:
+      w: 0.7071067811882787
+      x: 0.0
+      y: 0.7071067811848163
+      z: 0.0
+    position:
+      x: 0.0
+      y: 0.0
+      z: 0.0
+  joint_numbers:
+  - 0
+  - 1
+  - 2
+  - 3
+  - 4
+  - 5  
+joint_info:
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: joint_1
+  joint_limits:
+    effort: 1000.0
+    lower: -2.967
+    upper: 2.967
+    velocity: 5.027
+    acceleration: 10
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: joint_2
+  joint_limits:
+    effort: 1000.0
+    lower: -1.745
+    upper: 2.269
+    velocity: 4.189
+    acceleration: 15
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: joint_3
+  joint_limits:
+    effort: 1000.0
+    lower: -3.491
+    upper: 1.222
+    velocity: 5.236
+    acceleration: 15
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: joint_4
+  joint_limits:
+    effort: 1000.0
+    lower: -4.712
+    upper: 4.712
+    velocity: 6.981
+    acceleration: 20
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: joint_5
+  joint_limits:
+    effort: 1000.0
+    lower: -2.269
+    upper: 2.269
+    velocity: 7.069
+    acceleration: 20
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: joint_6
+  joint_limits:
+    effort: 1000.0
+    lower: -6.283
+    upper: 6.283
+    velocity: 10.472
+    acceleration: 20
+  joint_type: revolute
+  passive: false

--- a/test/sawyer_electric_gripper_default_config.yml
+++ b/test/sawyer_electric_gripper_default_config.yml
@@ -1,0 +1,44 @@
+device_info:
+  device:
+    name: sawyer_electric_gripper
+  manufacturer:
+    name: Rethink_Robotics
+    uuid: 82d22757-bbfc-44ca-9edb-8824c4a1943e
+  model:
+    name: Sawyer_Electric_Gripper
+    uuid: f9521686-6acc-4718-a637-f276463bfc3c
+  user_description: Rethink Robotics Sawyer Electric Gripper
+  serial_number: 123456789
+  device_classes:
+    - class_identifier:
+        name: gripper
+        uuid: ee974ee5-a5de-49c4-8fe6-831df8f2821c
+      subclasses: 
+        - electric
+  implemented_types:
+    - com.robotraconteur.robotics.tool.Tool
+tool_type: electric_gripper
+tool_capabilities:
+- open_close_command
+- continuous_command
+- homing_command
+tcp:
+  translation:
+    x: 0
+    y: 0
+    z: 0.1577
+  rotation:
+    x: 0
+    y: 0
+    z: 0.043619
+    w: 0.999048
+close_position: 0
+open_position: 0.041667
+command_min: 0
+command_max: 0.041667
+command_close: 0
+command_open: 0.041667
+sensor_min:
+  - 0
+sensor_max:
+  - 100

--- a/test/sawyer_robot_default_config.yml
+++ b/test/sawyer_robot_default_config.yml
@@ -1,0 +1,274 @@
+device_info:
+  device:
+    name: sawyer_robot
+  manufacturer:
+    name: Rethink_Robotics
+    uuid: 82d22757-bbfc-44ca-9edb-8824c4a1943e
+  model:
+    name: Sawyer
+    uuid: f965af3f-da91-41d7-be0f-871207c2185d
+  user_description: Rethink Robotics Sawyer Robot
+  serial_number: 123456789
+  device_classes:
+    - class_identifier:
+        name: robot
+        uuid: 39b513e7-21b9-4b49-8654-7537473030eb
+      subclasses: 
+        - serial
+        - serial_seven_axis
+        - cobot
+  implemented_types:
+    - com.robotraconteur.robotics.robot.Robot
+robot_type: serial
+robot_capabilities:
+- jog_command
+- trajectory_command
+- position_command
+- velocity_command
+- homing_command
+- software_reset_errors
+- software_enable
+chains:
+- kin_chain_identifier: right_arm
+  H:
+  - x: 0.0
+    y: 0.0
+    z: 1.0
+  - x: 4.896638650109253e-12
+    y: 1.0
+    z: 2.3977070069743767e-23
+  - x: 1.0
+    y: 0.0
+    z: 4.896638650109253e-12
+  - x: 4.896638650109253e-12
+    y: 1.0
+    z: 2.3977070069743767e-23
+  - x: 1.0
+    y: 0.0
+    z: 4.896638650109253e-12
+  - x: 4.896638650109253e-12
+    y: 1.0
+    z: 2.3977070069743767e-23
+  - x: 0.9999999999730151
+    y: -7.438845639614214e-14
+    z: -7.346406160283209e-06
+  P:
+  - x: 0.0
+    y: 0.0
+    z: 0.08
+  - x: 0.081
+    y: 0.05
+    z: 0.237
+  - x: 0.1400000000006978
+    y: 0.14249999999931445
+    z: 6.855294110187123e-13
+  - x: 0.26
+    y: -0.042
+    z: 1.2731260490284059e-12
+  - x: 0.12499999999938058
+    y: -0.12650000000061207
+    z: 6.120798312606236e-13
+  - x: 0.275
+    y: 0.031
+    z: 1.3465756287800448e-12
+  - x: 0.11000000000051562
+    y: 0.10529999999946138
+    z: 5.386302515145426e-13
+  - x: 0.024499999999338874
+    y: -1.8225171817054826e-15
+    z: -1.7998695092693863e-07
+  link_identifiers:
+  - right_arm_base_link
+  - right_l0
+  - right_l1
+  - right_l2
+  - right_l3
+  - right_l4
+  - right_l5
+  - right_l6
+  flange_identifier: right_hand
+  flange_pose:
+    orientation:
+      w: -0.4545185118693182
+      x: 0.5416766195837562
+      y: -0.4545218509592193
+      z: 0.5416726402219519
+    position:
+      x: 0.0
+      y: 0.0
+      z: 0.0
+  joint_numbers:
+  - 0
+  - 1
+  - 2
+  - 3
+  - 4
+  - 5
+  - 6  
+  link_inertias:
+  - com:
+      x: -0.0006241
+      y: -2.8025e-05
+      z: 0.065404
+    ixx: 0.006759900000000001
+    ixy: -4.2024e-05
+    ixz: -6.190400000000048e-07
+    iyy: 0.006787700000000001
+    iyz: 1.5888e-05
+    izz: 0.0074031
+    m: 2.0687
+  - com:
+      x: 0.024366000000000002
+      y: 0.010969
+      z: 0.14363
+    ixx: 0.053314
+    ixy: 0.0047093
+    ixz: 0.011734000000000003
+    iyy: 0.05790200000000001
+    iyz: 0.0080179
+    izz: 0.023659
+    m: 5.3213
+  - com:
+      x: -0.0030849
+      y: -0.026811
+      z: 0.092521
+    ixx: 0.022398
+    ixy: -0.00023986
+    ixz: -0.0002936200000000001
+    iyy: 0.014613000000000001
+    iyz: -0.0060875
+    izz: 0.017295
+    m: 4.505
+  - com:
+      x: -0.00016044
+      y: -0.014967
+      z: 0.13582
+    ixx: 0.025506
+    ixy: 4.4101e-06
+    ixz: 1.4955000000000002e-05
+    iyy: 0.025300000000000003
+    iyz: -0.0033204
+    izz: 0.0034179
+    m: 1.745
+  - com:
+      x: -0.0048135
+      y: -0.028100000000000003
+      z: -0.084154
+    ixx: 0.010160000000000002
+    ixy: -9.745199999999874e-06
+    ixz: 0.00026624000000000005
+    iyy: 0.006568499999999998
+    iyz: 0.003031600000000002
+    izz: 0.0069078
+    m: 2.5097
+  - com:
+      x: -0.0018844
+      y: 0.0069001
+      z: 0.1341
+    ixx: 0.013557
+    ixy: 1.8109000000000002e-05
+    ixz: 0.00013522999999999996
+    iyy: 0.013554999999999998
+    iyz: 0.0010561
+    izz: 0.0013658
+    m: 1.1136
+  - com:
+      x: 0.0061133
+      y: -0.023697
+      z: 0.076416
+    ixx: 0.0047328000000000005
+    ixy: 0.00011526000000000003
+    ixz: 4.626900000000004e-05
+    iyy: 0.002967599999999999
+    iyz: -0.0011557
+    izz: 0.0031762000000000006
+    m: 1.5625
+  - com:
+      x: -8.0726e-06
+      y: 0.0085838
+      z: -0.0049566
+    ixx: 0.00031105
+    ixy: 1.4771e-06
+    ixz: -3.7074e-07
+    iyy: 0.00021549
+    iyz: -8.4533e-06
+    izz: 0.00035976
+    m: 0.3292
+joint_info:
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: right_j0
+  joint_limits:
+    effort: 80.0
+    lower: -3.0503
+    upper: 3.0503
+    velocity: 1.74
+    acceleration: 3.5
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: right_j1
+  joint_limits:
+    effort: 80.0
+    lower: -3.8095
+    upper: 2.2736
+    velocity: 1.328
+    acceleration: 2.5
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: right_j2
+  joint_limits:
+    effort: 40.0
+    lower: -3.0426
+    upper: 3.0426
+    velocity: 1.957
+    acceleration: 5.0
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: right_j3
+  joint_limits:
+    effort: 40.0
+    lower: -3.0439
+    upper: 3.0439
+    velocity: 1.957
+    acceleration: 5.0
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: right_j4
+  joint_limits:
+    effort: 9.0
+    lower: -2.9761
+    upper: 2.9761
+    velocity: 3.485
+    acceleration: 5.0
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: right_j5
+  joint_limits:
+    effort: 9.0
+    lower: -2.9761
+    upper: 2.9761
+    velocity: 3.485
+    acceleration: 5.0
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: right_j6
+  joint_limits:
+    effort: 9.0
+    lower: -4.7124
+    upper: 4.7124
+    velocity: 4.545
+    acceleration: 5.0
+  joint_type: revolute
+  passive: false

--- a/test/sawyer_robot_with_electric_gripper_config.yml
+++ b/test/sawyer_robot_with_electric_gripper_config.yml
@@ -1,0 +1,319 @@
+device_info:
+  device:
+    name: sawyer_robot
+  manufacturer:
+    name: Rethink_Robotics
+    uuid: 82d22757-bbfc-44ca-9edb-8824c4a1943e
+  model:
+    name: Sawyer
+    uuid: f965af3f-da91-41d7-be0f-871207c2185d
+  user_description: Rethink Robotics Sawyer Robot
+  serial_number: 123456789
+  device_classes:
+    - class_identifier:
+        name: robot
+        uuid: 39b513e7-21b9-4b49-8654-7537473030eb
+      subclasses: 
+        - serial
+        - serial_seven_axis
+        - cobot
+  implemented_types:
+    - com.robotraconteur.robotics.robot.Robot
+robot_type: serial
+robot_capabilities:
+- jog_command
+- trajectory_command
+- position_command
+- velocity_command
+- homing_command
+- software_reset_errors
+- software_enable
+chains:
+- kin_chain_identifier: right_arm
+  H:
+  - x: 0.0
+    y: 0.0
+    z: 1.0
+  - x: 4.896638650109253e-12
+    y: 1.0
+    z: 2.3977070069743767e-23
+  - x: 1.0
+    y: 0.0
+    z: 4.896638650109253e-12
+  - x: 4.896638650109253e-12
+    y: 1.0
+    z: 2.3977070069743767e-23
+  - x: 1.0
+    y: 0.0
+    z: 4.896638650109253e-12
+  - x: 4.896638650109253e-12
+    y: 1.0
+    z: 2.3977070069743767e-23
+  - x: 0.9999999999730151
+    y: -7.438845639614214e-14
+    z: -7.346406160283209e-06
+  P:
+  - x: 0.0
+    y: 0.0
+    z: 0.08
+  - x: 0.081
+    y: 0.05
+    z: 0.237
+  - x: 0.1400000000006978
+    y: 0.14249999999931445
+    z: 6.855294110187123e-13
+  - x: 0.26
+    y: -0.042
+    z: 1.2731260490284059e-12
+  - x: 0.12499999999938058
+    y: -0.12650000000061207
+    z: 6.120798312606236e-13
+  - x: 0.275
+    y: 0.031
+    z: 1.3465756287800448e-12
+  - x: 0.11000000000051562
+    y: 0.10529999999946138
+    z: 5.386302515145426e-13
+  - x: 0.024499999999338874
+    y: -1.8225171817054826e-15
+    z: -1.7998695092693863e-07
+  link_identifiers:
+  - right_arm_base_link
+  - right_l0
+  - right_l1
+  - right_l2
+  - right_l3
+  - right_l4
+  - right_l5
+  - right_l6
+  flange_identifier: right_hand
+  flange_pose:
+    orientation:
+      w: -0.4545185118693182
+      x: 0.5416766195837562
+      y: -0.4545218509592193
+      z: 0.5416726402219519
+    position:
+      x: 0.0
+      y: 0.0
+      z: 0.0
+  joint_numbers:
+  - 0
+  - 1
+  - 2
+  - 3
+  - 4
+  - 5
+  - 6  
+  link_inertias:
+  - com:
+      x: -0.0006241
+      y: -2.8025e-05
+      z: 0.065404
+    ixx: 0.006759900000000001
+    ixy: -4.2024e-05
+    ixz: -6.190400000000048e-07
+    iyy: 0.006787700000000001
+    iyz: 1.5888e-05
+    izz: 0.0074031
+    m: 2.0687
+  - com:
+      x: 0.024366000000000002
+      y: 0.010969
+      z: 0.14363
+    ixx: 0.053314
+    ixy: 0.0047093
+    ixz: 0.011734000000000003
+    iyy: 0.05790200000000001
+    iyz: 0.0080179
+    izz: 0.023659
+    m: 5.3213
+  - com:
+      x: -0.0030849
+      y: -0.026811
+      z: 0.092521
+    ixx: 0.022398
+    ixy: -0.00023986
+    ixz: -0.0002936200000000001
+    iyy: 0.014613000000000001
+    iyz: -0.0060875
+    izz: 0.017295
+    m: 4.505
+  - com:
+      x: -0.00016044
+      y: -0.014967
+      z: 0.13582
+    ixx: 0.025506
+    ixy: 4.4101e-06
+    ixz: 1.4955000000000002e-05
+    iyy: 0.025300000000000003
+    iyz: -0.0033204
+    izz: 0.0034179
+    m: 1.745
+  - com:
+      x: -0.0048135
+      y: -0.028100000000000003
+      z: -0.084154
+    ixx: 0.010160000000000002
+    ixy: -9.745199999999874e-06
+    ixz: 0.00026624000000000005
+    iyy: 0.006568499999999998
+    iyz: 0.003031600000000002
+    izz: 0.0069078
+    m: 2.5097
+  - com:
+      x: -0.0018844
+      y: 0.0069001
+      z: 0.1341
+    ixx: 0.013557
+    ixy: 1.8109000000000002e-05
+    ixz: 0.00013522999999999996
+    iyy: 0.013554999999999998
+    iyz: 0.0010561
+    izz: 0.0013658
+    m: 1.1136
+  - com:
+      x: 0.0061133
+      y: -0.023697
+      z: 0.076416
+    ixx: 0.0047328000000000005
+    ixy: 0.00011526000000000003
+    ixz: 4.626900000000004e-05
+    iyy: 0.002967599999999999
+    iyz: -0.0011557
+    izz: 0.0031762000000000006
+    m: 1.5625
+  - com:
+      x: -8.0726e-06
+      y: 0.0085838
+      z: -0.0049566
+    ixx: 0.00031105
+    ixy: 1.4771e-06
+    ixz: -3.7074e-07
+    iyy: 0.00021549
+    iyz: -8.4533e-06
+    izz: 0.00035976
+    m: 0.3292
+  current_tool:
+    device_info:
+      device:
+        name: sawyer_electric_gripper
+      manufacturer:
+        name: Rethink_Robotics
+        uuid: 82d22757-bbfc-44ca-9edb-8824c4a1943e
+      model:
+        name: Sawyer_Electric_Gripper
+        uuid: f9521686-6acc-4718-a637-f276463bfc3c
+      user_description: Rethink Robotics Sawyer Electric Gripper
+      serial_number: 123456789
+      device_classes:
+        - class_identifier:
+            name: gripper
+            uuid: ee974ee5-a5de-49c4-8fe6-831df8f2821c
+          subclasses: 
+            - electric
+      implemented_types:
+        - com.robotraconteur.robotics.tool.Tool
+    tool_type: electric_gripper
+    tool_capabilities:
+    - open_close_command
+    - continuous_command
+    - homing_command
+    tcp:
+      translation:
+        x: 0
+        y: 0
+        z: 0.1577
+      rotation:
+        x: 0
+        y: 0
+        z: 0.043619
+        w: 0.999048
+    close_position: 0
+    open_position: 0.041667
+    command_min: 0
+    command_max: 0.041667
+    command_close: 0
+    command_open: 0.041667
+    sensor_min:
+      - 0
+    sensor_max:
+      - 100
+joint_info:
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: right_j0
+  joint_limits:
+    effort: 80.0
+    lower: -3.0503
+    upper: 3.0503
+    velocity: 1.74
+    acceleration: 3.5
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: right_j1
+  joint_limits:
+    effort: 80.0
+    lower: -3.8095
+    upper: 2.2736
+    velocity: 1.328
+    acceleration: 2.5
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: right_j2
+  joint_limits:
+    effort: 40.0
+    lower: -3.0426
+    upper: 3.0426
+    velocity: 1.957
+    acceleration: 5.0
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: right_j3
+  joint_limits:
+    effort: 40.0
+    lower: -3.0439
+    upper: 3.0439
+    velocity: 1.957
+    acceleration: 5.0
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: right_j4
+  joint_limits:
+    effort: 9.0
+    lower: -2.9761
+    upper: 2.9761
+    velocity: 3.485
+    acceleration: 5.0
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: right_j5
+  joint_limits:
+    effort: 9.0
+    lower: -2.9761
+    upper: 2.9761
+    velocity: 3.485
+    acceleration: 5.0
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: right_j6
+  joint_limits:
+    effort: 9.0
+    lower: -4.7124
+    upper: 4.7124
+    velocity: 4.545
+    acceleration: 5.0
+  joint_type: revolute
+  passive: false

--- a/test/sawyer_robot_with_electric_gripper_config.yml
+++ b/test/sawyer_robot_with_electric_gripper_config.yml
@@ -7,6 +7,17 @@ device_info:
   model:
     name: Sawyer
     uuid: f965af3f-da91-41d7-be0f-871207c2185d
+  device_origin_pose:
+    pose:
+      orientation:
+        w: 0.707107
+        x: 0
+        y: 0
+        z: -0.707107
+      position:
+        x: 0.5
+        y: 0.23
+        z: 0.8
   user_description: Rethink Robotics Sawyer Robot
   serial_number: 123456789
   device_classes:

--- a/test/test_rr_yaml.py
+++ b/test/test_rr_yaml.py
@@ -45,10 +45,10 @@ def test_robotinfo_yaml_loader_abb1200():
 def test_robotinfo_yaml_loader_sawyer_with_tool():
     with open(_get_absolute_path("sawyer_robot_with_electric_gripper_config.yml"), "r") as f:
         robot = rr_rox.load_robot_info_yaml_to_robot(f)
-    _assert_sawyer_robot(robot)
+    _assert_sawyer_robot(robot, T_base_expected=rox.Transform(rox.rot([0,0,1],-np.pi/2), [0.5, 0.23, 0.8]))
 
 
-def _assert_sawyer_robot(robot):
+def _assert_sawyer_robot(robot, T_base_expected = None):
 
     nptest.assert_allclose(robot.H, np.transpose(
         [[0, 0, 1], [0, 1, 0], [1, 0, 0], [0, 1, 0], [1, 0, 0], [0, 1, 0], [1, 0, 0]]), atol=1e-4)
@@ -74,7 +74,10 @@ def _assert_sawyer_robot(robot):
     nptest.assert_allclose(robot.R_tool, rox.rot(
         [0, 0, 1], np.deg2rad(5)), atol=1e-4)
     nptest.assert_allclose(robot.p_tool, [0, 0, 0.1577], atol=1e-4)
-    assert robot.T_base is None
+    if T_base_expected is None:
+        assert robot.T_base is None
+    else:
+        assert T_base_expected.isclose(robot.T_base, tol=1e-4)
     nptest.assert_allclose(rox.R2q(
         robot.T_flange.R), [-0.45451851, 0.54167662, -0.45452185, 0.54167264], atol=1e-4)
     nptest.assert_allclose(robot.T_flange.p, [0, 0, 0])

--- a/test/test_rr_yaml.py
+++ b/test/test_rr_yaml.py
@@ -1,0 +1,89 @@
+import general_robotics_toolbox as rox
+import numpy as np
+import pytest
+import os
+
+
+from general_robotics_toolbox import robotraconteur as rr_rox
+import numpy.testing as nptest
+
+
+def _get_absolute_path(fname):
+    dirname = os.path.dirname(os.path.realpath(__file__))
+    return dirname + "/" + fname
+
+
+def test_robotinfo_yaml_loader_abb1200():
+    with open(_get_absolute_path("abb_1200_5_90_robot_default_config.yml"), "r") as f:
+        robot = rr_rox.load_robot_info_yaml_to_robot(f)
+
+    nptest.assert_allclose(robot.H, np.transpose(
+        [[0, 0, 1], [0, 1, 0], [0, 1, 0], [1, 0, 0], [0, 1, 0], [1, 0, 0]]))
+    nptest.assert_allclose(robot.P, np.transpose([
+        [0.0, 0.0, 0.3991], [0.0, 0.0, 0.0], [0.0, 0.0, 0.448],
+        [0.0, 0.0, 0.042], [0.451, 0.0, 0.0], [0.082, 0.0, 0.0], [0.0, 0.0, 0.0]]))
+
+    nptest.assert_allclose(robot.joint_type, [0, 0, 0, 0, 0, 0])
+    nptest.assert_allclose(robot.joint_lower_limit,
+                           [-2.967, -1.745, -3.491, -4.712, -2.269, -6.283])
+    nptest.assert_allclose(robot.joint_upper_limit, [
+                           2.967, 2.269, 1.222, 4.712, 2.269, 6.283])
+    nptest.assert_allclose(robot.joint_vel_limit, [
+                           5.027, 4.189, 5.236, 6.981, 7.069, 10.472])
+    nptest.assert_allclose(robot.joint_acc_limit, [10, 15, 15, 20, 20, 20])
+    assert robot.joint_names == ['joint_1', 'joint_2',
+                                 'joint_3', 'joint_4', 'joint_5', 'joint_6']
+    assert robot.root_link_name is None
+    assert robot.tip_link_name == "tool0"
+    assert robot.R_tool is None and robot.p_tool is None
+    assert robot.T_base is None
+    nptest.assert_allclose(robot.T_flange.R, rox.rot(
+        [0, 1, 0], np.pi/2.), atol=1e-4)
+    nptest.assert_allclose(robot.T_flange.p, [0, 0, 0])
+
+
+def test_robotinfo_yaml_loader_sawyer_with_tool():
+    with open(_get_absolute_path("sawyer_robot_with_electric_gripper_config.yml"), "r") as f:
+        robot = rr_rox.load_robot_info_yaml_to_robot(f)
+    _assert_sawyer_robot(robot)
+
+
+def _assert_sawyer_robot(robot):
+
+    nptest.assert_allclose(robot.H, np.transpose(
+        [[0, 0, 1], [0, 1, 0], [1, 0, 0], [0, 1, 0], [1, 0, 0], [0, 1, 0], [1, 0, 0]]), atol=1e-4)
+    nptest.assert_allclose(robot.P, np.transpose([
+        [0.0, 0.0, 0.08], [0.081, 0.05, 0.237], [
+            0.14, 0.1425, 0.0], [0.26, -0.042, 0.0],
+        [0.125, -0.1265, 0.0], [0.275, 0.031, 0.0], [0.11, 0.1053, 0.0], [0.0245, 0.0, 0.0]]), atol=1e-4)
+
+    nptest.assert_allclose(robot.joint_type, [0, 0, 0, 0, 0, 0, 0])
+    nptest.assert_allclose(robot.joint_lower_limit,
+                           [-3.0503, -3.8095, -3.0426, -3.0439, -2.9761, -2.9761, -4.7124])
+    nptest.assert_allclose(robot.joint_upper_limit, [
+                           3.0503, 2.2736, 3.0426, 3.0439, 2.9761, 2.9761, 4.7124])
+    nptest.assert_allclose(robot.joint_vel_limit, [
+                           1.74, 1.328, 1.957, 1.957, 3.485, 3.485, 4.545])
+    nptest.assert_allclose(robot.joint_acc_limit, [
+                           3.5, 2.5, 5.0, 5.0, 5.0, 5.0, 5.0])
+    assert robot.joint_names == [
+        'right_j0', 'right_j1', 'right_j2', 'right_j3', 'right_j4', 'right_j5', 'right_j6']
+    assert robot.root_link_name == "right_arm_base_link"
+    assert robot.tip_link_name == "sawyer_electric_gripper"
+    # assert robot.R_tool is None and robot.p_tool is None
+    nptest.assert_allclose(robot.R_tool, rox.rot(
+        [0, 0, 1], np.deg2rad(5)), atol=1e-4)
+    nptest.assert_allclose(robot.p_tool, [0, 0, 0.1577], atol=1e-4)
+    assert robot.T_base is None
+    nptest.assert_allclose(rox.R2q(
+        robot.T_flange.R), [-0.45451851, 0.54167662, -0.45452185, 0.54167264], atol=1e-4)
+    nptest.assert_allclose(robot.T_flange.p, [0, 0, 0])
+
+
+def test_robotinfo_toolinfo_yaml_loader_sawyer():
+    with \
+            open(_get_absolute_path("sawyer_robot_default_config.yml"), "r") as f_robot, \
+            open(_get_absolute_path("sawyer_electric_gripper_default_config.yml"), "r") as f_tool:
+
+        robot = rr_rox.load_robot_and_tool_info_yaml_to_robot(f_robot, f_tool)
+        _assert_sawyer_robot(robot)


### PR DESCRIPTION
Robot Raconteur uses "info" yaml files to describe the parameters for robots and tools. This PR adds a "robotraconteur" module to the toolbox to load these yaml files into `Robot` classes. Adds functions `load_robot_info_yaml_to_robot()` and `load_robot_and_tool_info_yaml_to_robot()`. See the test_rr_yaml.py test file for examples on using the loader.