### PR TITLE
Add tesseract kinematics support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,15 @@ jobs:
       matrix:
         config:
           - python_version: "2.7"
+            tesseract_robotics: false
           - python_version: "3.6"
+            tesseract_robotics: false
           - python_version: "3.7"
+            tesseract_robotics: true
           - python_version: "3.8"
+            tesseract_robotics: true
           - python_version: "3.9"
+            tesseract_robotics: true
           - python_version: "3.10"
     steps:
     - uses: actions/checkout@v3
@@ -29,6 +34,9 @@ jobs:
         python-version: '${{ matrix.config.python_version }}'
     - name: pip
       run: python -m pip install pytest wheel setuptools
+    - name: pip tesseract-robotics
+      if: '${{ matrix.config.tesseract_robotics }}'
+      run: python -m pip install tesseract-robotics
     - name: pip local package
       run: pip install .
       working-directory: rpi_general_robotics_toolbox_py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
           - python_version: "3.9"
             tesseract_robotics: true
           - python_version: "3.10"
+            tesseract_robotics: true
     steps:
     - uses: actions/checkout@v3
       with:

--- a/src/general_robotics_toolbox/general_robotics_toolbox.py
+++ b/src/general_robotics_toolbox/general_robotics_toolbox.py
@@ -315,7 +315,9 @@ class Robot(object):
     :attribute joint_names: A list of N strings containing the names of the joints if loaded from URDF. Optional
     :attribute root_link_name: A string containing the name of the kinematic chain root link if loaded from URDF. Optional
     :attribute tip_link_name: A string containing the name of the kinematic chain tip link if loaded from URDF. Optional
-    
+    :attribute T_flange: Optional transform between end of kinematic chain and the tool frame. This is for compatibility
+                        with ROS tool formats.
+    :attribute T_base: Optional transform of base of robot in world frame.
     """
     
     
@@ -864,6 +866,10 @@ def unapply_robot_aux_transforms(robot, T):
         T_ret = robot.T_base.inv() * T_ret
 
     return T_ret
+
+def identity_transform():
+    """Returns an identity transform"""
+    return Transform(np.eye(3,dtype=np.float64),np.zeros((3,),dtype=np.float64))
 
 def random_R():
     q=np.random.rand(4)

--- a/src/general_robotics_toolbox/tesseract.py
+++ b/src/general_robotics_toolbox/tesseract.py
@@ -1,3 +1,9 @@
+import sys
+
+if sys.version_info < (3,6):
+    raise Exception("Python version 3.6 or higher required for Tesseract")
+
+
 import numpy as np
 from . import general_robotics_toolbox as rox
 

--- a/src/general_robotics_toolbox/tesseract.py
+++ b/src/general_robotics_toolbox/tesseract.py
@@ -1,0 +1,183 @@
+import numpy as np
+from . import general_robotics_toolbox as rox
+
+from tesseract_robotics.tesseract_common import Translation3d, AngleAxisd, Isometry3d
+from tesseract_robotics.tesseract_environment import Environment, Commands, \
+    AddLinkCommand, AddKinematicsInformationCommand, AddSceneGraphCommand
+from tesseract_robotics.tesseract_scene_graph import Link, Joint, JointLimits, \
+    JointType_FIXED, JointType_REVOLUTE, JointType_PRISMATIC, SceneGraph
+from tesseract_robotics.tesseract_common import FilesystemPath, ManipulatorInfo, KinematicsPluginInfo, \
+    PluginInfoContainer
+from tesseract_robotics.tesseract_kinematics import KinGroupIKInput, KinGroupIKInputs
+from tesseract_robotics.tesseract_srdf import KinematicsInformation
+
+def _transform_to_isometry3d(T):
+    # TODO: Use better Isometry3d constructor
+    return Translation3d(T.p) * AngleAxisd(T.R)
+
+def _get_link_and_joint(h, p, joint_type, joint_lower_limit, joint_upper_limit, joint_vel_limit,
+    joint_acc_limit, joint_effort_limit, link_name, joint_name, parent_link_name):
+    
+    link = Link(link_name)
+    joint = Joint(joint_name)
+
+    if joint_type == 0:      
+        joint.type = JointType_REVOLUTE
+    elif joint_type == 1:
+        joint.type = JointType_PRISMATIC
+    else:
+        assert False, "Unsupported Tesseract joint type: " + str(joint.type)
+    joint.parent_to_joint_origin_transform = _transform_to_isometry3d(rox.Transform(np.eye(3), p))
+    joint.axis = h
+    joint.parent_link_name = parent_link_name
+    joint.child_link_name = link_name
+    joint.limits = JointLimits(joint_lower_limit, joint_upper_limit, joint_effort_limit,
+         joint_vel_limit, joint_acc_limit)
+    return link,joint
+
+def _get_fixed_link_and_joint(T, link_name, joint_name, parent_link_name):
+    link = Link(link_name)
+    joint = Joint(joint_name)
+
+    joint.type = JointType_FIXED
+    joint.parent_to_joint_origin_transform = _transform_to_isometry3d(T)
+    joint.parent_link_name = parent_link_name
+    joint.child_link_name = link_name
+    return link,joint
+
+def _get_robot_world_to_base_joint(robot, robot_name):
+    joint = Joint(f"world_to_{robot_name}")
+
+    joint.type = JointType_FIXED
+    if robot.T_base:
+        joint.parent_to_joint_origin_transform = _transform_to_isometry3d(robot.T_base)
+    else:
+        joint.parent_to_joint_origin_transform = Isometry3d()
+    joint.parent_link_name = "world"
+    joint.child_link_name = f"{robot_name}_base_link"
+    return joint
+
+def robot_to_scene_graph(robot, return_names = False, invkin_solver = ""):
+    sg = SceneGraph()
+
+    sg_link_names = ["base_link"]
+
+    assert sg.addLink(Link("base_link"))
+    n_joints = len(robot.joint_type)
+
+    if robot.joint_names is None:
+        joint_names = [f"joint_{i+1}" for i in range(n_joints)]
+    else:
+        joint_names = robot.joint_names
+
+    # if robot.link_names is None:
+    link_names = [f"link_{i}" for i in range(n_joints+1)]
+    # else:
+        # link_names = [_p(s) for s in robot.link_names]
+
+    assert len(joint_names) == n_joints
+
+    for i in range(n_joints):
+        if i == 0:
+            parent_link_name = "base_link"
+        else:
+            parent_link_name = link_names[i-1]
+        
+        assert sg.addLink(*_get_link_and_joint(robot.H[:,i], robot.P[:,i], robot.joint_type[i], 
+            robot.joint_lower_limit[i], robot.joint_upper_limit[i], robot.joint_vel_limit[i], 
+            robot.joint_acc_limit[i], 1000.0, link_names[i], joint_names[i],
+            parent_link_name))
+        sg_link_names.append(link_names[i])
+    
+    assert sg.addLink(*_get_fixed_link_and_joint(rox.Transform(np.eye(3), robot.P[:,n_joints-1]), 
+        link_names[n_joints], link_names[n_joints] + "_chain_tip", link_names[n_joints-1]))
+    sg_link_names.append(link_names[n_joints])
+
+    tip_link = link_names[n_joints]
+
+    flange_link_name = "flange"
+
+    if robot.T_flange is not None:
+        assert sg.addLink(*_get_fixed_link_and_joint(robot.T_flange,
+            flange_link_name, "tip_to_flange", tip_link))
+
+        tip_link = flange_link_name
+        sg_link_names.append(flange_link_name)
+
+    tool_link_name = "tool_tcp"
+
+    if robot.R_tool is not None and robot.p_tool is not None:
+        assert sg.addLink(*_get_fixed_link_and_joint(rox.Transform(robot.R_tool, robot.p_tool),
+            tool_link_name, "tip_to_tool", tip_link))
+
+        tip_link = tool_link_name
+        sg_link_names.append(tool_link_name)
+    
+    if not return_names:
+        return sg
+    else:
+        return sg, sg_link_names, joint_names
+
+def world_scene_graph(world_link_name = "world"):
+    sg = SceneGraph()
+    sg.addLink(Link(world_link_name))
+    return sg
+
+
+def robot_to_tesseract_env_commands(robot, robot_name = "robot", include_world = True, return_names = False):
+        
+    commands = Commands()
+    
+    if include_world:
+        world_sg = world_scene_graph()
+        commands.append(AddSceneGraphCommand(world_sg))
+
+    robot_sg, sg_link_names, sg_joint_names = robot_to_scene_graph(robot, return_names = True)
+    robot_base_joint = _get_robot_world_to_base_joint(robot, robot_name)
+    commands.append(AddSceneGraphCommand(robot_sg, robot_base_joint, f"{robot_name}_"))
+
+    link_names = [f"{robot_name}_{s}" for s in sg_link_names]
+    joint_names = [f"{robot_name}_{s}" for s in sg_joint_names]
+    
+    # if robot.joint_names is None:
+    #     joint_names = [f"{robot_name}_joint_{i+1}" for i in range(len(robot.joint_type))]
+    # else:
+    #     joint_names = [f"{robot_name}_{s}" for s in robot.joint_names]
+    
+    kinematics_information = KinematicsInformation()
+    kinematics_information.addJointGroup(robot_name, joint_names)
+    commands.append(AddKinematicsInformationCommand(kinematics_information))
+
+    if not return_names:
+        return commands
+    else:
+        return commands, link_names, joint_names
+
+def kinematics_plugin_fwdkin_kdl_command(plugin_factory, robot_name, base_link, tip_link):
+    plugin_config = {
+        "kinematic_plugins": {
+            "search_libraries": [
+                "tesseract_kinematics_kdl_factories"
+            ],
+            "fwk_kin_plugins": {
+                robot_name: {
+                    "default": "KDLFwdKinChain",
+                    "plugins": {
+                        "KDLFwdKinChain": {
+                            "class": "KDLFwdKinChainFactory",
+                            "config": {
+                                "base_link": base_link,
+                                "tip_link": tip_link
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    PluginInfoContainer()
+
+    plugin_info = KinematicsPluginInfo()
+
+ 

--- a/src/general_robotics_toolbox/tesseract.py
+++ b/src/general_robotics_toolbox/tesseract.py
@@ -537,8 +537,8 @@ def kinematics_plugin_info_dict(robot, robot_name, link_names, joint_names, chai
                 base_link, tip_link, invkin_solver)
         elif invkin_solver == "OPWInvKin":
             opw_params = robot_to_opw_inv_kin_parameters(robot)
-            invkin_plugin_info, invkin_libs = kinematics_plugin_invkin_opw_plugin_info_dict(robot_name, base_link,
-                tip_link, opw_params)
+            invkin_plugin_info, invkin_libs = kinematics_plugin_invkin_opw_plugin_info_dict(robot_name, chain_link_names[0],
+                robot_name + "_flange", opw_params)
         elif invkin_solver == "URInvKin":
             ur_params = robot_to_ur_inv_kin_parameters(robot)
             invkin_plugin_info, invkin_libs = kinematics_plugin_invkin_ur_plugin_info_dict(robot_name, base_link,
@@ -632,6 +632,10 @@ def robot_to_opw_inv_kin_parameters(robot):
     ex = np.array([1.,0.,0.])
     ey = np.array([0.,1.,0.])
     ez = np.array([0.,0.,1.])
+
+    assert robot.T_flange
+    assert np.allclose(robot.T_flange.R, rox.rot([0,1,0], np.pi/2.0))
+    assert np.allclose(robot.T_flange.p.flatten(), np.array([0.,0.,0.]))
 
     assert len(robot.joint_type) == 6
 

--- a/src/general_robotics_toolbox/tesseract.py
+++ b/src/general_robotics_toolbox/tesseract.py
@@ -431,4 +431,13 @@ def kinematics_plugin_invkin_opw_plugin_info_dict(robot_name, base_link, tip_lin
 
     return plugin_info, ["tesseract_kinematics_opw_factories"]
 
+def robot_to_tesseract_env(robot, robot_name = "robot", include_world = True, 
+    invkin_solver = None, invkin_plugin_info = None):
 
+    tesseract_env_commands = robot_to_tesseract_env_commands(robot, robot_name, include_world, False, invkin_solver, 
+        invkin_plugin_info)
+
+    env = Environment()
+    assert env.init(tesseract_env_commands)
+
+    return env

--- a/src/general_robotics_toolbox/tesseract.py
+++ b/src/general_robotics_toolbox/tesseract.py
@@ -431,13 +431,16 @@ def kinematics_plugin_invkin_opw_plugin_info_dict(robot_name, base_link, tip_lin
 
     return plugin_info, ["tesseract_kinematics_opw_factories"]
 
-def robot_to_tesseract_env(robot, robot_name = "robot", include_world = True, 
+def robot_to_tesseract_env(robot, robot_name = "robot", include_world = True, return_names = False, 
     invkin_solver = None, invkin_plugin_info = None):
 
-    tesseract_env_commands = robot_to_tesseract_env_commands(robot, robot_name, include_world, False, invkin_solver, 
-        invkin_plugin_info)
+    tesseract_env_commands, link_names, joint_names = robot_to_tesseract_env_commands(robot, 
+        robot_name, include_world, True, invkin_solver, invkin_plugin_info)
 
     env = Environment()
     assert env.init(tesseract_env_commands)
 
-    return env
+    if not return_names:
+        return env
+    else:
+        return env, link_names, joint_names

--- a/src/general_robotics_toolbox/tesseract.py
+++ b/src/general_robotics_toolbox/tesseract.py
@@ -956,6 +956,14 @@ def robot_to_ur_inv_kin_parameters(robot):
     ey = np.array([0.,1.,0.])
     ez = np.array([0.,0.,1.])
 
+    assert robot.T_flange
+    assert np.allclose(robot.T_flange.R, np.array([ex, ez, -ey]).T, atol=1e-6)
+    assert np.allclose(robot.T_flange.p.flatten(), np.array([0.,0.,0.]))
+
+    assert robot.T_base
+    assert np.allclose(robot.T_base.R, rox.rot([0,0,1], np.pi), atol=1e-6)
+    assert np.allclose(robot.T_base.p.flatten(), np.array([0.,0.,0.]))
+
     minus_x = np.allclose(robot.H, np.array([ez,-ey,-ey,-ey,-ez,-ey]).T)
     plus_x = np.allclose(robot.H, -np.array([ez,-ey,-ey,-ey,-ez,-ey]).T)
 

--- a/src/general_robotics_toolbox/tesseract.py
+++ b/src/general_robotics_toolbox/tesseract.py
@@ -1,7 +1,7 @@
 import numpy as np
 from . import general_robotics_toolbox as rox
 
-from tesseract_robotics.tesseract_common import Translation3d, AngleAxisd, Isometry3d
+from tesseract_robotics.tesseract_common import Translation3d, AngleAxisd, Isometry3d, vector_pair_string
 from tesseract_robotics.tesseract_environment import Environment, Commands, \
     AddLinkCommand, AddKinematicsInformationCommand, AddSceneGraphCommand
 from tesseract_robotics.tesseract_scene_graph import Link, Joint, JointLimits, \
@@ -9,7 +9,9 @@ from tesseract_robotics.tesseract_scene_graph import Link, Joint, JointLimits, \
 from tesseract_robotics.tesseract_common import FilesystemPath, ManipulatorInfo, KinematicsPluginInfo, \
     PluginInfoContainer
 from tesseract_robotics.tesseract_kinematics import KinGroupIKInput, KinGroupIKInputs
-from tesseract_robotics.tesseract_srdf import KinematicsInformation
+from tesseract_robotics.tesseract_srdf import KinematicsInformation, parseKinematicsPluginConfigString
+import yaml
+import io
 
 def _transform_to_isometry3d(T):
     # TODO: Use better Isometry3d constructor
@@ -57,7 +59,10 @@ def _get_robot_world_to_base_joint(robot, robot_name):
     joint.child_link_name = f"{robot_name}_base_link"
     return joint
 
-def robot_to_scene_graph(robot, return_names = False, invkin_solver = ""):
+def _prefix_names(names, robot_name):
+    return [f"{robot_name}_{n}" for n in names]
+
+def robot_to_scene_graph(robot, return_names = False):
     sg = SceneGraph()
 
     sg_link_names = ["base_link"]
@@ -71,7 +76,7 @@ def robot_to_scene_graph(robot, return_names = False, invkin_solver = ""):
         joint_names = robot.joint_names
 
     # if robot.link_names is None:
-    link_names = [f"link_{i}" for i in range(n_joints+1)]
+    link_names = [f"link_{i+1}" for i in range(n_joints)]
     # else:
         # link_names = [_p(s) for s in robot.link_names]
 
@@ -89,11 +94,11 @@ def robot_to_scene_graph(robot, return_names = False, invkin_solver = ""):
             parent_link_name))
         sg_link_names.append(link_names[i])
     
-    assert sg.addLink(*_get_fixed_link_and_joint(rox.Transform(np.eye(3), robot.P[:,n_joints-1]), 
-        link_names[n_joints], link_names[n_joints] + "_chain_tip", link_names[n_joints-1]))
-    sg_link_names.append(link_names[n_joints])
+    assert sg.addLink(*_get_fixed_link_and_joint(rox.Transform(np.eye(3), robot.P[:,n_joints]), 
+        "chain_tip", link_names[n_joints-1] + "_to_chain_tip", link_names[n_joints-1]))
+    sg_link_names.append("chain_tip")
 
-    tip_link = link_names[n_joints]
+    tip_link = "chain_tip"
 
     flange_link_name = "flange"
 
@@ -116,7 +121,7 @@ def robot_to_scene_graph(robot, return_names = False, invkin_solver = ""):
     if not return_names:
         return sg
     else:
-        return sg, sg_link_names, joint_names
+        return sg, sg_link_names, joint_names, ["base_link"] + link_names
 
 def world_scene_graph(world_link_name = "world"):
     sg = SceneGraph()
@@ -124,7 +129,32 @@ def world_scene_graph(world_link_name = "world"):
     return sg
 
 
-def robot_to_tesseract_env_commands(robot, robot_name = "robot", include_world = True, return_names = False):
+def tesseract_kinematics_information(robot, robot_name, link_names, joint_names, chain_link_names, invkin_solver = None, 
+    invkin_plugin_info = None, base_link = None, tip_link = None):
+    
+    if base_link is None:
+        base_link = link_names[0]
+    if tip_link is None:
+        tip_link = link_names[-1]
+
+    kinematics_information = KinematicsInformation()
+    chain_group = vector_pair_string()
+    chain_group.append((base_link, tip_link))
+    kinematics_information.addChainGroup(robot_name, chain_group)
+    
+    plugin_info_str = kinematics_plugin_info_string(robot, robot_name, link_names, joint_names, chain_link_names,
+        invkin_solver, invkin_plugin_info, base_link, tip_link)
+
+    
+    plugin_info = parseKinematicsPluginConfigString(plugin_info_str)
+
+    kinematics_information.kinematics_plugin_info = plugin_info
+
+    return kinematics_information
+
+
+def robot_to_tesseract_env_commands(robot, robot_name = "robot", include_world = True, return_names = False, 
+    invkin_solver = None, invkin_plugin_info = None):
         
     commands = Commands()
     
@@ -132,20 +162,21 @@ def robot_to_tesseract_env_commands(robot, robot_name = "robot", include_world =
         world_sg = world_scene_graph()
         commands.append(AddSceneGraphCommand(world_sg))
 
-    robot_sg, sg_link_names, sg_joint_names = robot_to_scene_graph(robot, return_names = True)
+    robot_sg, sg_link_names, sg_joint_names, sg_chain_link_names = robot_to_scene_graph(robot, return_names = True)
     robot_base_joint = _get_robot_world_to_base_joint(robot, robot_name)
     commands.append(AddSceneGraphCommand(robot_sg, robot_base_joint, f"{robot_name}_"))
 
-    link_names = [f"{robot_name}_{s}" for s in sg_link_names]
-    joint_names = [f"{robot_name}_{s}" for s in sg_joint_names]
+    link_names = _prefix_names(sg_link_names, robot_name)
+    joint_names = _prefix_names(sg_joint_names, robot_name)
+    chain_link_names = _prefix_names(sg_chain_link_names, robot_name)
     
     # if robot.joint_names is None:
     #     joint_names = [f"{robot_name}_joint_{i+1}" for i in range(len(robot.joint_type))]
     # else:
     #     joint_names = [f"{robot_name}_{s}" for s in robot.joint_names]
     
-    kinematics_information = KinematicsInformation()
-    kinematics_information.addJointGroup(robot_name, joint_names)
+    kinematics_information = tesseract_kinematics_information(robot, robot_name, link_names, joint_names, 
+        chain_link_names, invkin_solver, invkin_plugin_info, "world", link_names[-1])
     commands.append(AddKinematicsInformationCommand(kinematics_information))
 
     if not return_names:
@@ -153,31 +184,103 @@ def robot_to_tesseract_env_commands(robot, robot_name = "robot", include_world =
     else:
         return commands, link_names, joint_names
 
-def kinematics_plugin_fwdkin_kdl_command(plugin_factory, robot_name, base_link, tip_link):
-    plugin_config = {
-        "kinematic_plugins": {
-            "search_libraries": [
-                "tesseract_kinematics_kdl_factories"
-            ],
-            "fwk_kin_plugins": {
-                robot_name: {
-                    "default": "KDLFwdKinChain",
-                    "plugins": {
-                        "KDLFwdKinChain": {
-                            "class": "KDLFwdKinChainFactory",
-                            "config": {
-                                "base_link": base_link,
-                                "tip_link": tip_link
-                            }
+def kinematics_plugin_fwdkin_kdl_plugin_info_dict(robot_name, base_link, tip_link):
+    plugin_info = {        
+        "fwd_kin_plugins": {
+            robot_name: {
+                "default": "KDLFwdKinChain",
+                "plugins": {
+                    "KDLFwdKinChain": {
+                        "class": "KDLFwdKinChainFactory",
+                        "config": {
+                            "base_link": base_link,
+                            "tip_link": tip_link
                         }
                     }
                 }
             }
         }
     }
+    
+    return plugin_info, ["tesseract_kinematics_kdl_factories"]
 
-    PluginInfoContainer()
+def kinematics_plugin_invkin_kdl_plugin_info_dict(robot_name, base_link, tip_link, default_solver = "KDLInvKinChainLMA"):
+    plugin_info = {
+        "inv_kin_plugins": {
+            robot_name: {
+                "default": default_solver,
+                "plugins": {
+                    "KDLInvKinChainLMA": {
+                        "class": "KDLInvKinChainLMAFactory",
+                        "config": {
+                            "base_link": base_link,
+                            "tip_link": tip_link
+                        }
+                    },
+                    "KDLInvKinChainNR": {
+                        "class": "KDLInvKinChainNRFactory",
+                        "config": {
+                            "base_link": base_link,
+                            "tip_link": tip_link
+                        }
+                    }
+                }
+            }
+        }        
+    }
 
-    plugin_info = KinematicsPluginInfo()
+    return plugin_info, ["tesseract_kinematics_kdl_factories"]
 
- 
+def kinematics_plugin_info_dict(robot, robot_name, link_names, joint_names, chain_link_names, invkin_solver = None, 
+    invkin_plugin_info = None, base_link = None, tip_link = None):
+    
+    if base_link is None:
+        base_link = link_names[0]
+
+    if tip_link is None:
+        tip_link = link_names[-1]
+
+    # fwdkin_solver = "KDLFwdKinChain"
+    fwdkin_plugin_info, fwdkin_libs = kinematics_plugin_fwdkin_kdl_plugin_info_dict(
+        robot_name, base_link, tip_link)
+
+    if invkin_solver is None:
+        invkin_solver = "KDLInvKinChainLMA"
+
+    if invkin_plugin_info is not None:
+        invkin_plugin_info, invkin_libs = invkin_plugin_info
+    else:
+
+        if invkin_solver == "KDLInvKinChainLMA" or invkin_solver == "KDLInvKinChainNR":
+            invkin_plugin_info, invkin_libs = kinematics_plugin_invkin_kdl_plugin_info_dict(robot_name,
+                base_link, tip_link, invkin_solver)
+        elif invkin_solver == "OPWInvKin":
+            assert False, "OPWInvKin not implemented"
+        elif invkin_solver == "URInvKin":
+            assert False, "URInvKin not implemented"
+        else:
+            assert False, "Unknown inverse kinematics solver"
+
+    libs = set(fwdkin_libs + invkin_libs)
+
+    plugin_info_dict = {
+        "kinematic_plugins": {
+            "search_libraries": list(libs),        
+            "fwd_kin_plugins": fwdkin_plugin_info["fwd_kin_plugins"],
+            "inv_kin_plugins": invkin_plugin_info["inv_kin_plugins"],
+        }
+    }
+
+    return plugin_info_dict
+        
+def kinematics_plugin_info_string(robot, robot_name, link_names, joint_names, chain_link_names, invkin_solver = None, 
+    invkin_plugin_info = None, base_link = None, tip_link = None):
+
+    plugin_info_dict = kinematics_plugin_info_dict(robot, robot_name, link_names, joint_names, chain_link_names,
+        invkin_solver, invkin_plugin_info, base_link, tip_link)
+
+    f = io.StringIO()
+    yaml.safe_dump(plugin_info_dict, f)
+    plugin_info_str = f.getvalue()
+
+    return plugin_info_str

--- a/src/general_robotics_toolbox/tesseract.py
+++ b/src/general_robotics_toolbox/tesseract.py
@@ -18,6 +18,7 @@ from tesseract_robotics.tesseract_kinematics import KinGroupIKInput, KinGroupIKI
 from tesseract_robotics.tesseract_srdf import KinematicsInformation, parseKinematicsPluginConfigString
 import yaml
 import io
+from typing import NamedTuple
 
 def transform_to_isometry3d(T):
     # TODO: Use better Isometry3d constructor
@@ -66,7 +67,9 @@ def get_robot_world_to_base_joint(robot, robot_name):
     if robot.T_base:
         joint.parent_to_joint_origin_transform = transform_to_isometry3d(robot.T_base)
     else:
-        joint.parent_to_joint_origin_transform = Isometry3d()
+        iso_base = Isometry3d()
+        iso_base.setIdentity()
+        joint.parent_to_joint_origin_transform = iso_base
     joint.parent_link_name = "world"
     joint.child_link_name = f"{robot_name}_base_link"
     return joint
@@ -267,7 +270,9 @@ def kinematics_plugin_info_dict(robot, robot_name, link_names, joint_names, chai
             invkin_plugin_info, invkin_libs = kinematics_plugin_invkin_kdl_plugin_info_dict(robot_name,
                 base_link, tip_link, invkin_solver)
         elif invkin_solver == "OPWInvKin":
-            assert False, "OPWInvKin not implemented"
+            opw_params = robot_to_opw_inv_kin_parameters(robot)
+            invkin_plugin_info, invkin_libs = kinematics_plugin_invkin_opw_plugin_info_dict(robot_name, base_link,
+                tip_link, opw_params)
         elif invkin_solver == "URInvKin":
             assert False, "URInvKin not implemented"
         else:
@@ -296,3 +301,134 @@ def kinematics_plugin_info_string(robot, robot_name, link_names, joint_names, ch
     plugin_info_str = f.getvalue()
 
     return plugin_info_str
+
+class OPWInvKinParameters(NamedTuple):
+    a1: float
+    a2: float
+    b: float
+    c1: float
+    c2: float
+    c3: float
+    c4: float
+    offsets: np.array
+    sign_corrections: np.array
+
+def robot_to_opw_inv_kin_parameters(robot):
+    """
+    Convert "Robot" structure to OPW Kinematics parameters
+    a1, a2, b, c1, c2, c3, c4, offsets, and sign_corrections.
+
+    See https://github.com/Jmeyer1292/opw_kinematics for definitions of these parameters.
+
+    This function uses a heuristic method to guess the correct configuration. The following must be true:
+
+    * Robot has six joints, with a vertical first axis, two parallel and orthogonal joints, and a spherical wrist.
+    (Orthogonal, parallel, wrist OPW) format.
+
+    The heuristic algorithm requires that h1 = z, h2 = h3 = y, and h5 = y. h4 = h5 may be either along x or z, depending
+    if the robot home position is outstretched along X or Z. Most ROS Industrial robots use the X outstretched format,
+    with either Joint 2 or Joint 3 bent 90 degrees from the vertical configuration. The heuristic will check to see
+    if the bend is in one of these joints, and attempt to align with the expected OPW configuration with the robot
+    outstretched vertically.
+    """
+
+    ex = np.array([1.,0.,0.])
+    ey = np.array([0.,1.,0.])
+    ez = np.array([0.,0.,1.])
+
+    assert len(robot.joint_type) == 6
+
+    assert np.allclose(robot.H[:,0], ez) 
+    assert np.allclose(robot.H[:,1], ey)
+    assert np.allclose(robot.H[:,2], ey)
+    assert np.allclose(robot.H[:,4], ey)
+    assert np.allclose(robot.H[:,3], robot.H[:,5])
+    assert np.allclose(robot.H[:,5], ez) or np.allclose(robot.H[:,5], ex)
+
+    P2 = np.copy(robot.P)
+
+    offset = np.zeros((6,))
+    sign_corrections = np.ones((6,))
+
+    if np.allclose(robot.H[:,5], ex):
+        # Check if bend is at joint 2 or 3
+        if np.abs(P2[0,2]) > np.abs(P2[2,2]):
+            # x is greater than z for link 2, assume bend at joint 2
+            R = rox.rot(ey, -np.pi/2.0)
+            P2[:,2:] = np.matmul(R, P2[:,2:])
+            offset[1] = -np.pi/2.0
+        elif np.abs(P2[0,3] + P2[0,4]) > np.abs(P2[2,3] + P2[2,4]):
+            # x is greater than z for link 3, assume bend at joint 3
+            R = rox.rot(ey, -np.pi/2.0)
+            P2[:,3:] = np.matmul(R, P2[:,3:])
+            offset[2] = -np.pi/2.0
+        else:
+            # unclear where bend is, assume Joint 2
+            R = rox.rot(ey, -np.pi/2.0)
+            P2[:,2:] = np.matmul(R, P2[:,2:])
+            offset[1] = -np.pi/2.0
+
+    if not np.isclose(P2[0,2],0.0):
+        q2_op = -np.arctan2(P2[0,2], P2[2,2])
+        P2[:,2] = np.matmul(rox.rot(ey,q2_op),P2[:,2])
+        offset[1] += q2_op
+        offset[2] -= q2_op
+
+    assert np.allclose(P2[0:2,0], 0.0)
+    assert np.allclose(P2[0:2,4:], 0.0)
+    assert np.allclose(P2[0,2], 0.0)
+
+    c1 = np.round(P2[2,0] + P2[2,1],6).item()
+    c2 = np.round(P2[2,2],6).item()
+    c3 = np.round(P2[2,3] + P2[2,4],6).item()
+    c4 = np.round(P2[2,5] + P2[2,6],6).item()
+
+    a1 = np.round(P2[0,1],6).item()
+    a2 = np.round(P2[0,3],6).item()
+    b = np.round(P2[1,1] + P2[1,2] + P2[1,3],6).item()
+
+    return OPWInvKinParameters(
+        a1,
+        a2,
+        b,
+        c1,
+        c2,
+        c3,
+        c4,
+        np.round(offset,8),
+        np.round(sign_corrections,8)
+    )
+    
+def kinematics_plugin_invkin_opw_plugin_info_dict(robot_name, base_link, tip_link, opw_params):
+    plugin_info = {
+        "inv_kin_plugins": {
+            robot_name: {
+                "default": "OPWInvKin",
+                "plugins": {
+                    "OPWInvKin": {
+                        "class": "OPWInvKinFactory",
+                        "config": {
+                            "base_link": base_link,
+                            "tip_link": tip_link,
+                            "params": {
+                                "a1": opw_params.a1,
+                                "a2": opw_params.a2,
+                                "b": opw_params.b,
+                                "c1": opw_params.c1,
+                                "c2": opw_params.c2,
+                                "c3": opw_params.c3,
+                                "c4": opw_params.c4,
+                                "offsets": opw_params.offsets.tolist(),
+                                "sign_corrections": np.asarray(opw_params.sign_corrections,dtype=np.uint8).tolist()
+
+                            }
+                        }
+                    },
+                }
+            }
+        }        
+    }
+
+    return plugin_info, ["tesseract_kinematics_opw_factories"]
+
+

--- a/src/general_robotics_toolbox/tesseract.py
+++ b/src/general_robotics_toolbox/tesseract.py
@@ -443,7 +443,7 @@ def kinematics_plugin_fwdkin_kdl_plugin_info_dict(robot_name, base_link, tip_lin
         }
     }
     
-    return plugin_info, ["tesseract_kinematics_kdl_factories"]
+    return plugin_info, [] #["tesseract_kinematics_kdl_factories"]
 
 def kinematics_plugin_invkin_kdl_plugin_info_dict(robot_name, base_link, tip_link, default_solver = "KDLInvKinChainLMA"):
     """

--- a/src/general_robotics_toolbox/tesseract.py
+++ b/src/general_robotics_toolbox/tesseract.py
@@ -14,7 +14,7 @@ from tesseract_robotics.tesseract_scene_graph import Link, Joint, JointLimits, \
     JointType_FIXED, JointType_REVOLUTE, JointType_PRISMATIC, SceneGraph
 from tesseract_robotics.tesseract_common import FilesystemPath, ManipulatorInfo, KinematicsPluginInfo, \
     PluginInfoContainer
-from tesseract_robotics.tesseract_kinematics import KinGroupIKInput, KinGroupIKInputs
+from tesseract_robotics.tesseract_kinematics import KinGroupIKInput, KinGroupIKInputs, getRedundantSolutions
 from tesseract_robotics.tesseract_srdf import KinematicsInformation, parseKinematicsPluginConfigString
 import yaml
 import io
@@ -519,6 +519,10 @@ class TesseractRobot:
             ret.append(invkin1[i].flatten())
         return ret
 
+    def redundant_solutions(self, theta):
+        kin_group = self.tesseract_env.getKinematicGroup(self.robot_name)
+        return redundant_solutions(kin_group, theta)
+
 class URInvKinParameters(NamedTuple):
     d1: float
     a2: float
@@ -599,3 +603,11 @@ def kinematics_plugin_invkin_ur_plugin_info_dict(robot_name, base_link, tip_link
     }
 
     return plugin_info, ["tesseract_kinematics_ur_factories"]
+
+def redundant_solutions(tesseract_kin_group, theta):
+    limits = tesseract_kin_group.getLimits()
+    redundancy_indices = list(tesseract_kin_group.getRedundancyCapableJointIndices())
+
+    redun_sol = getRedundantSolutions(theta, limits.joint_limits, redundancy_indices)
+
+    return [x.flatten() for x in redun_sol]

--- a/test/rp260_robot_default_config.yml
+++ b/test/rp260_robot_default_config.yml
@@ -1,4 +1,4 @@
-﻿device_info:
+device_info:
   device:
     name: rp260_robot
   manufacturer:

--- a/test/rp260_robot_default_config.yml
+++ b/test/rp260_robot_default_config.yml
@@ -1,0 +1,164 @@
+﻿device_info:
+  device:
+    name: rp260_robot
+  manufacturer:
+    name: RP_Automation
+    uuid: e14a3241-159d-4c25-81fb-19eff378d5b3
+  model:
+    name: RP260
+    uuid: 3fd21c0a-8f15-4d0a-84af-2ce5f9f71979
+  user_description: RP Automation 260 Robot
+  serial_number: 123456789
+  device_classes:
+    - class_identifier:
+        name: robot
+        uuid: 39b513e7-21b9-4b49-8654-7537473030eb
+      subclasses: 
+        - serial
+        - serial_six_axis        
+  implemented_types:
+    - com.robotraconteur.robotics.robot.Robot
+  device_origin_pose:
+    pose:
+      orientation:
+        w: 0.707107
+        x: 0
+        y: 0
+        z: -0.707107
+      position:
+        x: 0.5
+        y: 0.23
+        z: 0.8
+robot_type: serial
+robot_capabilities:
+- jog_command
+- trajectory_command
+- position_command
+chains:
+- kin_chain_identifier: robot_arm
+  H:
+  - x: 0.0
+    y: 0.0
+    z: 1.0
+  - x: 0.0
+    y: 1.0
+    z: 0.0
+  - x: 0.0
+    y: 1.0
+    z: 0.0
+  - x: 1.0
+    y: 0.0
+    z: 0.0
+  - x: 0.0
+    y: 1.0
+    z: 0.0
+  - x: 1.0
+    y: 0.0
+    z: 0.0
+  P:
+  - x: 0.0
+    y: 0.0
+    z: 0.3302
+  - x: 0.0
+    y: 0.0
+    z: 0.0
+  - x: 0.19812
+    y: -0.12446
+    z: -0.01905
+  - x: 0.2032
+    y: 0.0
+    z: 0.0
+  - x: 0.0
+    y: 0.0
+    z: 0.0
+  - x: 0.0635
+    y: 0.0
+    z: 0.0
+  - x: 0.0
+    y: 0.0
+    z: 0.0
+  flange_identifier: tool0
+  flange_pose:
+    orientation:
+      w: 0.7071067811882787
+      x: 0.0
+      y: 0.7071067811848163
+      z: 0.0
+    position:
+      x: 0.0
+      y: 0.0
+      z: 0.0
+  joint_numbers:
+  - 0
+  - 1
+  - 2
+  - 3
+  - 4
+  - 5
+joint_info:
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: joint_1
+  joint_limits:
+    effort: 100.0
+    lower: -1.57079632679
+    upper: 3.49065850399
+    velocity: 2.07694180987
+    acceleration: 1
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: joint_2
+  joint_limits:
+    effort: 100.0
+    lower: -4.18879020479
+    upper: 1.308996939
+    velocity: 2.07694180987
+    acceleration: 1
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: joint_3
+  joint_limits:
+    effort: 100.0
+    lower: -2.53072741539
+    upper: 2.53072741539
+    velocity: 2.86233997327
+    acceleration: 1
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: joint_4
+  joint_limits:
+    effort: 100.0
+    lower: -3.22885911619
+    upper: 6.28318530718
+    velocity: 10.070549784
+    acceleration: 1
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: joint_5
+  joint_limits:
+    effort: 100.0
+    lower: -2.09439510239
+    upper: 2.09439510239
+    velocity: 7.5223690761
+    acceleration: 1
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: joint_6
+  joint_limits:
+    effort: 100.0
+    lower: -6.28318530718
+    upper: 1.57079632679
+    velocity: 6.92895713042
+    acceleration: 1
+  joint_type: revolute
+  passive: false

--- a/test/test_tesseract_kinematics.py
+++ b/test/test_tesseract_kinematics.py
@@ -1,0 +1,83 @@
+
+import pytest
+import sys
+
+if sys.version_info[0] < 3:
+    pytest.skip("skipping Tesseract tests on Python 2", allow_module_level=True)
+
+import general_robotics_toolbox as rox
+import numpy as np
+import numpy.testing as nptest
+import os
+
+tesseract_common = pytest.importorskip('tesseract_robotics.tesseract_common')
+
+from general_robotics_toolbox import tesseract as rox_tesseract
+from general_robotics_toolbox import robotraconteur as rr_rox
+
+from tesseract_robotics.tesseract_scene_graph import \
+    JointType_FIXED, JointType_REVOLUTE, JointType_PRISMATIC
+from tesseract_robotics.tesseract_environment import Environment
+
+def _assert_rox_eig_transform_close(T, eig_iso):
+    H_eig_iso = eig_iso.matrix()
+    H_T = np.zeros((4,4),dtype=np.float64)
+    H_T[0:3,0:3] = T.R
+    H_T[0:3,3] = T.p
+    H_T[3,3] = 1.0
+
+    nptest.assert_allclose(H_eig_iso, H_T, atol = 1e-4)
+
+def test_transform_to_isometry3d():
+    T = rox.random_transform()
+    eig_iso = rox_tesseract._transform_to_isometry3d(T)
+    _assert_rox_eig_transform_close(T, eig_iso)
+
+def test_get_fixed_link_command():
+    T = rox.random_transform()
+    link, joint = rox_tesseract._get_fixed_link_and_joint(T, "my_link", "my_joint", "my_parent_link")
+    assert link.getName() == "my_link"
+    assert joint.parent_link_name == "my_parent_link"
+    assert joint.child_link_name == "my_link"
+    assert joint.getName() == "my_joint"
+    _assert_rox_eig_transform_close(T, joint.parent_to_joint_origin_transform)
+
+def test_get_link_command():
+    p = rox.random_p()
+    h = rox.random_p()
+    h = h/np.linalg.norm(h)
+
+    link, joint = rox_tesseract._get_link_and_joint(h, p, 0, -np.rad2deg(24), np.rad2deg(34),
+        7.92, 8.92, 6.432, "my_link4", "my_joint8", "my_link3")
+
+    assert link.getName() == "my_link4"
+    assert joint.parent_link_name == "my_link3"
+    assert joint.child_link_name == "my_link4"
+    assert joint.getName() == "my_joint8"
+    _assert_rox_eig_transform_close(rox.Transform(np.eye(3),p), 
+        joint.parent_to_joint_origin_transform)
+    nptest.assert_allclose(h, joint.axis.flatten(), atol=1e-6)
+    assert joint.type == JointType_REVOLUTE
+
+    limits = joint.limits
+    assert limits.lower == -np.rad2deg(24)
+    assert limits.upper == np.rad2deg(34)
+    assert limits.velocity == 7.92
+    assert limits.acceleration == 8.92
+    assert limits.effort == 6.432
+
+def _get_absolute_path(fname):
+    dirname = os.path.dirname(os.path.realpath(__file__))
+    return dirname + "/" + fname
+
+def test_robot_to_tesseract_env_commands():
+    with open(_get_absolute_path("sawyer_robot_with_electric_gripper_config.yml"), "r") as f:
+        robot = rr_rox.load_robot_info_yaml_to_robot(f)
+
+    tesseract_env_commands = rox_tesseract.robot_to_tesseract_env_commands(robot, "sawyer")
+    env = Environment()
+    env.init(tesseract_env_commands)
+
+    kin_info = env.getKinematicsInformation()
+
+    print(kin_info)

--- a/test/test_tesseract_kinematics.py
+++ b/test/test_tesseract_kinematics.py
@@ -372,6 +372,7 @@ def _assert_tesseract_kinematics(robot, tesseract_robot):
         nptest.assert_allclose(J1,J2,atol=1e-6)
 
         q_ik = tesseract_robot.invkin(T1, q*0.1)
+        assert len(q_ik) > 0
         for q_ik_i in q_ik:
             T_ik = rox.fwdkin(robot,q_ik_i)
             # KDL invkin solver has low accuracy
@@ -398,5 +399,25 @@ def test_tesseract_robot_sawyer():
         robot = rr_rox.load_robot_info_yaml_to_robot(f)
 
     tesseract_robot = rox_tesseract.TesseractRobot(robot, "robot")
+
+    _assert_tesseract_kinematics(robot, tesseract_robot)
+
+def test_ur_inv_kin_params_ur5e():
+    with open(_get_absolute_path("ur5e_robot_default_config.yml"), "r") as f:
+        robot = rr_rox.load_robot_info_yaml_to_robot(f)
+    ur_params = rox_tesseract.robot_to_ur_inv_kin_parameters(robot)
+
+    assert ur_params.d1 == 0.1625
+    assert ur_params.a2 == -0.425
+    assert ur_params.a3 == -0.3922
+    assert ur_params.d4 == 0.1333
+    assert ur_params.d5 == 0.0997
+    assert ur_params.d6 == 0.0996
+
+def test_tesseract_robot_ur5e():
+    with open(_get_absolute_path("ur5e_robot_default_config.yml"), "r") as f:
+        robot = rr_rox.load_robot_info_yaml_to_robot(f)
+
+    tesseract_robot = rox_tesseract.TesseractRobot(robot, "robot", invkin_solver="URInvKin")
 
     _assert_tesseract_kinematics(robot, tesseract_robot)

--- a/test/test_tesseract_kinematics.py
+++ b/test/test_tesseract_kinematics.py
@@ -253,8 +253,7 @@ def test_kinematics_plugin_info_string_abb1200():
     '              - 0.0\n              - -1.57079633\n              - 0.0\n              - 0.0\n' \
     '              - 0.0\n              sign_corrections:\n              - 1\n              - 1\n' \
     '              - 1\n              - 1\n              - 1\n              - 1\n' \
-    '            tip_link: flange\n  search_libraries:\n  - tesseract_kinematics_opw_factories\n' \
-    '  - tesseract_kinematics_kdl_factories\n'
+    '            tip_link: flange\n  search_libraries:\n  - tesseract_kinematics_opw_factories\n'
 
     assert kin_plugin_info == kin_plugin_info_expected
 
@@ -303,7 +302,7 @@ def test_opw_inv_kin_params_rp260():
     kin_group = env.getKinematicGroup("robot")
     assert kin_group is not None
 
-    q = np.ones((6,),dtype=np.float64)*np.deg2rad(15)
+    q = -np.ones((6,),dtype=np.float64)*np.deg2rad(15)
     fwdkin_res = kin_group.calcFwdKin(q)
     tcp_pose = fwdkin_res["robot_flange"]
     

--- a/test/test_tesseract_kinematics.py
+++ b/test/test_tesseract_kinematics.py
@@ -155,9 +155,9 @@ def test_robot_to_tesseract_env_commands_and_kin_sawyer():
     assert set(kin_group_joint_names) == set(['sawyer_right_j0', 'sawyer_right_j1', 'sawyer_right_j2', 'sawyer_right_j3', 
         'sawyer_right_j4', 'sawyer_right_j5', 'sawyer_right_j6'])
 
-    assert set(kin_group_link_names) == set(['sawyer_link_5', 'sawyer_base_link', 'world', 'sawyer_link_1', 
-        'sawyer_link_0', 'sawyer_link_2', 'sawyer_link_3', 'sawyer_link_4', 'sawyer_link_6', 'sawyer_link_7',
-        'sawyer_flange', 'sawyer_tool_tcp'])
+    assert set(kin_group_link_names) == set(['sawyer_link_5', 'sawyer_base_link', 'world', 'sawyer_link_1',
+     'sawyer_link_2', 'sawyer_link_3', 'sawyer_link_4', 'sawyer_link_6',
+     'sawyer_link_7', 'sawyer_chain_tip', 'sawyer_flange', 'sawyer_tool_tcp'])
 
     q = np.ones((7,),dtype=np.float64)*np.deg2rad(15)
     tcp_pose = kin_group.calcFwdKin(q)["sawyer_tool_tcp"]
@@ -169,7 +169,7 @@ def test_robot_to_tesseract_env_commands_and_kin_sawyer():
     iks = KinGroupIKInputs()
     iks.append(ik)
 
-    invkin1 = kin_group.calcInvKin(iks,q*0.7)
+    invkin1 = kin_group.calcInvKin(iks,q*0.8)
 
     nptest.assert_allclose(q, invkin1[0].flatten(), atol=np.deg2rad(0.5))
 
@@ -187,9 +187,9 @@ def test_kinematics_plugin_info_string_sawyer():
     '      plugins:\n        KDLFwdKinChain:\n          class: KDLFwdKinChainFactory\n          config:\n' \
     '            base_link: base_link\n            tip_link: tool_tcp\n  inv_kin_plugins:\n    my_robot:\n' \
     '      default: KDLInvKinChainNR\n      plugins:\n        KDLInvKinChainLMA:\n' \
-    '          class: KDLInvKinChainLMAFactory\n          config:\n            base_link: link_0\n' \
-    '            tip_link: link_7\n        KDLInvKinChainNR:\n          class: KDLInvKinChainNRFactory\n' \
-    '          config:\n            base_link: link_0\n            tip_link: link_7\n  search_libraries:\n' \
+    '          class: KDLInvKinChainLMAFactory\n          config:\n            base_link: base_link\n' \
+    '            tip_link: tool_tcp\n        KDLInvKinChainNR:\n          class: KDLInvKinChainNRFactory\n' \
+    '          config:\n            base_link: base_link\n            tip_link: tool_tcp\n  search_libraries:\n' \
     '  - tesseract_kinematics_kdl_factories\n'
 
     assert kin_plugin_info == kin_plugin_info_expected

--- a/test/test_tesseract_kinematics.py
+++ b/test/test_tesseract_kinematics.py
@@ -18,6 +18,8 @@ from general_robotics_toolbox import robotraconteur as rr_rox
 from tesseract_robotics.tesseract_scene_graph import \
     JointType_FIXED, JointType_REVOLUTE, JointType_PRISMATIC
 from tesseract_robotics.tesseract_environment import Environment
+from tesseract_robotics.tesseract_common import TransformMap, Isometry3d
+from tesseract_robotics.tesseract_kinematics import KinGroupIKInput, KinGroupIKInputs
 
 def _assert_rox_eig_transform_close(T, eig_iso):
     H_eig_iso = eig_iso.matrix()
@@ -70,14 +72,124 @@ def _get_absolute_path(fname):
     dirname = os.path.dirname(os.path.realpath(__file__))
     return dirname + "/" + fname
 
-def test_robot_to_tesseract_env_commands():
+def _assert_sg_joint(sg_joint, name, parent, child, sg_type, h, p, l, u, v, a):
+    assert sg_joint.getName() == name
+    assert sg_joint.parent_link_name == parent
+    assert sg_joint.child_link_name == child
+    assert sg_joint.type == sg_type
+    sg_limits = sg_joint.limits
+    assert sg_limits.lower == l
+    assert sg_limits.upper == u
+    assert sg_limits.velocity == v
+    assert sg_limits.acceleration == a
+
+    _assert_rox_eig_transform_close(rox.Transform(np.eye(3),p), 
+        sg_joint.parent_to_joint_origin_transform)
+    nptest.assert_allclose(h, sg_joint.axis.flatten(), atol=1e-5)
+    
+def _assert_sg_fixed_joint(sg_joint, name, parent, child, q, p):
+    assert sg_joint.getName() == name
+    assert sg_joint.parent_link_name == parent
+    assert sg_joint.child_link_name == child
+    assert sg_joint.type == JointType_FIXED
+    T = rox.Transform(rox.q2R(q),p)
+    _assert_rox_eig_transform_close(T, sg_joint.parent_to_joint_origin_transform)
+
+def test_robot_to_scene_graph_sawyer():
+    with open(_get_absolute_path("sawyer_robot_with_electric_gripper_config.yml"), "r") as f:
+        robot = rr_rox.load_robot_info_yaml_to_robot(f)
+
+    sg, link_names, joint_names, chain_link_names = rox_tesseract.robot_to_scene_graph(robot, True)
+
+    assert link_names == ['base_link', 'link_1', 'link_2', 'link_3', 'link_4', 'link_5', 'link_6', 'link_7',
+     'chain_tip', 'flange', 'tool_tcp']
+         
+    assert joint_names ==  ['right_j0', 'right_j1', 'right_j2', 'right_j3', 'right_j4', 'right_j5', 'right_j6']
+    assert chain_link_names == ['base_link', 'link_1', 'link_2', 'link_3', 'link_4', 'link_5', 'link_6', 'link_7']
+
+    sg_links_v = sg.getLinks()
+    sg_joints_v = sg.getJoints()
+    sg_links = {sg_links_v[i].getName(): sg_links_v[i] for i in range(len(sg_links_v))}
+    sg_joints = {sg_joints_v[i].getName(): sg_joints_v[i] for i in range(len(sg_joints_v))}
+
+    assert set(sg_links.keys()) == set(['link_1', 'base_link', 'link_2', 'link_3', 'link_4', 'link_5', 'link_6', 
+        'link_7', 'chain_tip', 'flange', 'tool_tcp'])
+    assert set(sg_joints.keys()) == set(['right_j0', 'right_j1', 'right_j2', 'link_7_to_chain_tip',
+         'right_j3', 'right_j4', 'right_j5', 'right_j6', 'tip_to_flange', 'tip_to_tool'])
+
+    _assert_sg_joint(sg_joints["right_j0"], "right_j0", "base_link", "link_1", JointType_REVOLUTE, 
+    [0,0,1], [0,0,0.08], -3.0503, 3.0503, 1.74, 3.5)
+    _assert_sg_joint(sg_joints["right_j1"], "right_j1", "link_1", "link_2", JointType_REVOLUTE, 
+    [0,1,0], [0.081,0.05,0.237], -3.8095, 2.2736, 1.328, 2.5)
+    _assert_sg_joint(sg_joints["right_j2"], "right_j2", "link_2", "link_3", JointType_REVOLUTE, 
+    [1,0,0], [0.14,0.1425,0], -3.0426, 3.0426, 1.957, 5.0)
+    _assert_sg_joint(sg_joints["right_j3"], "right_j3", "link_3", "link_4", JointType_REVOLUTE, 
+    [0,1,0], [0.26,-0.042,0], -3.0439, 3.0439, 1.957, 5.0)
+    _assert_sg_joint(sg_joints["right_j4"], "right_j4", "link_4", "link_5", JointType_REVOLUTE, 
+    [1,0,0], [0.125,-0.1265,0], -2.9761, 2.9761, 3.485, 5.0)
+    _assert_sg_joint(sg_joints["right_j5"], "right_j5", "link_5", "link_6", JointType_REVOLUTE, 
+    [0,1,0], [0.275,0.031,0], -2.9761, 2.9761, 3.485, 5.0)
+    _assert_sg_joint(sg_joints["right_j6"], "right_j6", "link_6", "link_7", JointType_REVOLUTE, 
+    [1,0,0], [0.11,0.1053,0], -4.7124, 4.7124, 4.545, 5.0)
+    _assert_sg_fixed_joint(sg_joints["link_7_to_chain_tip"], "link_7_to_chain_tip", "link_7", "chain_tip", \
+        [1,0,0,0], [0.0245,0,0])
+    _assert_sg_fixed_joint(sg_joints["tip_to_flange"], "tip_to_flange", "chain_tip", "flange", \
+        [-0.454518, 0.541676, -0.454521, 0.541672], [0,0,0])
+    _assert_sg_fixed_joint(sg_joints["tip_to_tool"], "tip_to_tool", "flange", "tool_tcp", \
+        [0.999048, 0, 0, 0.043619], [0,0,0.1577])
+
+def test_robot_to_tesseract_env_commands_and_kin_sawyer():
     with open(_get_absolute_path("sawyer_robot_with_electric_gripper_config.yml"), "r") as f:
         robot = rr_rox.load_robot_info_yaml_to_robot(f)
 
     tesseract_env_commands = rox_tesseract.robot_to_tesseract_env_commands(robot, "sawyer")
     env = Environment()
-    env.init(tesseract_env_commands)
+    assert env.init(tesseract_env_commands)
 
-    kin_info = env.getKinematicsInformation()
+    # kin_info = env.getKinematicsInformation()
+    kin_group = env.getKinematicGroup("sawyer")
+    kin_group_joint_names = kin_group.getJointNames()
+    kin_group_link_names = kin_group.getLinkNames()
 
-    print(kin_info)
+
+    assert set(kin_group_joint_names) == set(['sawyer_right_j0', 'sawyer_right_j1', 'sawyer_right_j2', 'sawyer_right_j3', 
+        'sawyer_right_j4', 'sawyer_right_j5', 'sawyer_right_j6'])
+
+    assert set(kin_group_link_names) == set(['sawyer_link_5', 'sawyer_base_link', 'world', 'sawyer_link_1', 
+        'sawyer_link_0', 'sawyer_link_2', 'sawyer_link_3', 'sawyer_link_4', 'sawyer_link_6', 'sawyer_link_7',
+        'sawyer_flange', 'sawyer_tool_tcp'])
+
+    q = np.ones((7,),dtype=np.float64)*np.deg2rad(15)
+    tcp_pose = kin_group.calcFwdKin(q)["sawyer_tool_tcp"]
+    
+    ik = KinGroupIKInput()
+    ik.pose = tcp_pose
+    ik.tip_link_name = "sawyer_tool_tcp"
+    ik.working_frame = "world"
+    iks = KinGroupIKInputs()
+    iks.append(ik)
+
+    invkin1 = kin_group.calcInvKin(iks,q*0.7)
+
+    nptest.assert_allclose(q, invkin1[0].flatten(), atol=np.deg2rad(0.5))
+
+
+def test_kinematics_plugin_info_string_sawyer():
+    with open(_get_absolute_path("sawyer_robot_with_electric_gripper_config.yml"), "r") as f:
+        robot = rr_rox.load_robot_info_yaml_to_robot(f)
+
+    sg, link_names, joint_names, chain_link_names = rox_tesseract.robot_to_scene_graph(robot,True)
+
+    kin_plugin_info = rox_tesseract.kinematics_plugin_info_string(robot, "my_robot", link_names, joint_names, chain_link_names,
+        "KDLInvKinChainNR")
+
+    kin_plugin_info_expected = 'kinematic_plugins:\n  fwd_kin_plugins:\n    my_robot:\n      default: KDLFwdKinChain\n' \
+    '      plugins:\n        KDLFwdKinChain:\n          class: KDLFwdKinChainFactory\n          config:\n' \
+    '            base_link: base_link\n            tip_link: tool_tcp\n  inv_kin_plugins:\n    my_robot:\n' \
+    '      default: KDLInvKinChainNR\n      plugins:\n        KDLInvKinChainLMA:\n' \
+    '          class: KDLInvKinChainLMAFactory\n          config:\n            base_link: link_0\n' \
+    '            tip_link: link_7\n        KDLInvKinChainNR:\n          class: KDLInvKinChainNRFactory\n' \
+    '          config:\n            base_link: link_0\n            tip_link: link_7\n  search_libraries:\n' \
+    '  - tesseract_kinematics_kdl_factories\n'
+
+    assert kin_plugin_info == kin_plugin_info_expected

--- a/test/test_tesseract_kinematics.py
+++ b/test/test_tesseract_kinematics.py
@@ -32,12 +32,14 @@ def _assert_rox_eig_transform_close(T, eig_iso):
 
 def test_transform_to_isometry3d():
     T = rox.random_transform()
-    eig_iso = rox_tesseract._transform_to_isometry3d(T)
+    eig_iso = rox_tesseract.transform_to_isometry3d(T)
     _assert_rox_eig_transform_close(T, eig_iso)
+    T2 = rox_tesseract.isometry3d_to_transform(eig_iso)
+    assert T.isclose(T2)
 
 def test_get_fixed_link_command():
     T = rox.random_transform()
-    link, joint = rox_tesseract._get_fixed_link_and_joint(T, "my_link", "my_joint", "my_parent_link")
+    link, joint = rox_tesseract.get_fixed_link_and_joint(T, "my_link", "my_joint", "my_parent_link")
     assert link.getName() == "my_link"
     assert joint.parent_link_name == "my_parent_link"
     assert joint.child_link_name == "my_link"
@@ -49,7 +51,7 @@ def test_get_link_command():
     h = rox.random_p()
     h = h/np.linalg.norm(h)
 
-    link, joint = rox_tesseract._get_link_and_joint(h, p, 0, -np.rad2deg(24), np.rad2deg(34),
+    link, joint = rox_tesseract.get_link_and_joint(h, p, 0, -np.rad2deg(24), np.rad2deg(34),
         7.92, 8.92, 6.432, "my_link4", "my_joint8", "my_link3")
 
     assert link.getName() == "my_link4"

--- a/test/test_tesseract_kinematics.py
+++ b/test/test_tesseract_kinematics.py
@@ -253,7 +253,7 @@ def test_kinematics_plugin_info_string_abb1200():
     '              - 0.0\n              - -1.57079633\n              - 0.0\n              - 0.0\n' \
     '              - 0.0\n              sign_corrections:\n              - 1\n              - 1\n' \
     '              - 1\n              - 1\n              - 1\n              - 1\n' \
-    '            tip_link: flange\n  search_libraries:\n  - tesseract_kinematics_opw_factories\n'
+    '            tip_link: my_robot_flange\n  search_libraries:\n  - tesseract_kinematics_opw_factories\n'
 
     assert kin_plugin_info == kin_plugin_info_expected
 
@@ -317,7 +317,7 @@ def test_opw_inv_kin_params_rp260():
     fwdkin_res2 = kin_group.calcFwdKin(invkin1[0])
     tcp_pose2 = fwdkin_res2["robot_flange"]
 
-    nptest.assert_allclose(q, invkin1[0].flatten(), atol=np.deg2rad(0.1))
+    # nptest.assert_allclose(q, invkin1[0].flatten(), atol=np.deg2rad(0.1))
     nptest.assert_allclose(tcp_pose.matrix(), tcp_pose2.matrix(), atol=1e-5)
 
 def test_robot_to_tesseract_env_and_kin_sawyer():

--- a/test/test_tesseract_kinematics.py
+++ b/test/test_tesseract_kinematics.py
@@ -414,6 +414,7 @@ def test_ur_inv_kin_params_ur5e():
     assert ur_params.d5 == 0.0997
     assert ur_params.d6 == 0.0996
 
+@pytest.mark.skip(reason="URInvKin solver possible bug")
 def test_tesseract_robot_ur5e():
     with open(_get_absolute_path("ur5e_robot_default_config.yml"), "r") as f:
         robot = rr_rox.load_robot_info_yaml_to_robot(f)

--- a/test/test_tesseract_kinematics.py
+++ b/test/test_tesseract_kinematics.py
@@ -457,3 +457,28 @@ def test_tesseract_redundant_solution():
 
     nptest.assert_allclose(redun_sol[0], 
         np.array([0.08726646, 0.08726646,  0.08726646, 0.08726646, 0.08726646, -6.19591884]))
+
+def test_tesseract_robot_example():
+    with open(_get_absolute_path("abb_1200_5_90_robot_default_config.yml"), "r") as f:
+        robot = rr_rox.load_robot_info_yaml_to_robot(f)
+    
+    tesseract_robot = rox_tesseract.TesseractRobot(robot, "robot", invkin_solver="OPWInvKin")
+
+    # Random joint angles
+    q = np.array([0.1, 0.11, 0.12, 0.13, 0.14, 0.15])
+
+    # Compute forward kinematics
+    T_tip_link = tesseract_robot.fwdkin(q)
+
+    # Compute robot Jacobian
+    J = tesseract_robot.jacobian(q)
+
+    # Solve inverse kinematics for T_des pose
+    T_des = rox.Transform(rox.rot([0,1,0], np.deg2rad(80)), np.array([0.5,0.1,0.71]))
+    invkin1 = tesseract_robot.invkin(T_des,q*0.7)
+
+    # Find redundant solutions for first candidate joint angle
+    invkin1_redun = []
+    for invkin1_i in invkin1:
+        invkin1_redun.extend(tesseract_robot.redundant_solutions(invkin1_i))
+

--- a/test/test_tesseract_kinematics.py
+++ b/test/test_tesseract_kinematics.py
@@ -413,7 +413,6 @@ def test_ur_inv_kin_params_ur5e():
     assert ur_params.d5 == 0.0997
     assert ur_params.d6 == 0.0996
 
-@pytest.mark.skip(reason="URInvKin solver possible bug")
 def test_tesseract_robot_ur5e():
     with open(_get_absolute_path("ur5e_robot_default_config.yml"), "r") as f:
         robot = rr_rox.load_robot_info_yaml_to_robot(f)

--- a/test/test_tesseract_kinematics.py
+++ b/test/test_tesseract_kinematics.py
@@ -422,3 +422,38 @@ def test_tesseract_robot_ur5e():
     tesseract_robot = rox_tesseract.TesseractRobot(robot, "robot", invkin_solver="URInvKin")
 
     _assert_tesseract_kinematics(robot, tesseract_robot)
+
+def test_tesseract_redundant_solutions_tesseract_function():
+    with open(_get_absolute_path("abb_1200_5_90_robot_default_config.yml"), "r") as f:
+        robot = rr_rox.load_robot_info_yaml_to_robot(f)
+
+    env = rox_tesseract.robot_to_tesseract_env(robot, "sawyer")
+
+    # kin_info = env.getKinematicsInformation()
+    kin_group = env.getKinematicGroup("sawyer")
+
+    limits = kin_group.getLimits()
+    redundancy_indices = list(kin_group.getRedundancyCapableJointIndices())
+
+    import tesseract_robotics.tesseract_kinematics as tes_com
+    sol = np.ones((6,1))*np.deg2rad(5)
+    redun_sol = tes_com.getRedundantSolutions(sol, limits.joint_limits, redundancy_indices)
+    
+    assert len(redun_sol) == 1
+
+    nptest.assert_allclose(redun_sol[0].flatten(), 
+        np.array([0.08726646, 0.08726646,  0.08726646, 0.08726646, 0.08726646, -6.19591884]))
+
+def test_tesseract_redundant_solution():
+    with open(_get_absolute_path("abb_1200_5_90_robot_default_config.yml"), "r") as f:
+        robot = rr_rox.load_robot_info_yaml_to_robot(f)
+
+    tesseract_robot = rox_tesseract.TesseractRobot(robot, "sawyer")
+
+    sol = np.ones((6,1))*np.deg2rad(5)
+    redun_sol = tesseract_robot.redundant_solutions(sol)
+    
+    assert len(redun_sol) == 1
+
+    nptest.assert_allclose(redun_sol[0], 
+        np.array([0.08726646, 0.08726646,  0.08726646, 0.08726646, 0.08726646, -6.19591884]))

--- a/test/ur5e_robot_default_config.yml
+++ b/test/ur5e_robot_default_config.yml
@@ -19,6 +19,17 @@ device_info:
         - cobot
   implemented_types:
     - com.robotraconteur.robotics.robot.Robot
+  device_origin_pose:
+    pose:
+      orientation:
+        w: 0
+        x: 0
+        y: 0
+        z: 1
+      position:
+        x: 0
+        y: 0
+        z: 0
 robot_type: serial
 robot_capabilities:
 - jog_command

--- a/test/ur5e_robot_default_config.yml
+++ b/test/ur5e_robot_default_config.yml
@@ -1,0 +1,156 @@
+device_info:
+  device:
+    name: ur5e_robot
+  manufacturer:
+    name: Universal_Robots
+    uuid: d80db3c2-3de8-41e3-97f9-62765a7063b8
+  model:
+    name: UR5e
+    uuid: 774ab965-651e-4d8e-876c-7d3732120d5b
+  user_description: Universal Robots UR5e Robot
+  serial_number: 123456789
+  device_classes:
+    - class_identifier:
+        name: robot
+        uuid: 39b513e7-21b9-4b49-8654-7537473030eb
+      subclasses: 
+        - serial
+        - serial_six_axis
+        - cobot
+  implemented_types:
+    - com.robotraconteur.robotics.robot.Robot
+robot_type: serial
+robot_capabilities:
+- jog_command
+- trajectory_command
+- position_command
+- velocity_command
+chains:
+- H:
+  - x: 0.0
+    y: 0.0
+    z: 1.0
+  - x: 0.0
+    y: -1.0
+    z: -0.0
+  - x: 0.0
+    y: -1.0
+    z: -0.0
+  - x: 0.0
+    y: -1.0
+    z: -0.0
+  - x: 0.0
+    y: 0.0
+    z: -1.0
+  - x: 0.0
+    y: -1.0
+    z: -0.0
+  P:
+  - x: 0.0
+    y: 0.0
+    z: 0.1625
+  - x: 0.0
+    y: 0.0
+    z: 0.0
+  - x: -0.425
+    y: 0.0
+    z: 0.0
+  - x: -0.3922
+    y: -0.1333
+    z: -0.0
+  - x: 0.0
+    y: 0.0
+    z: -0.0997
+  - x: 0.0
+    y: -0.0996
+    z: -0.0
+  - x: 0.0
+    y: 0.0
+    z: 0.0
+  flange_identifier: tool0
+  flange_pose:
+    orientation:
+      w: 0.707107
+      x: 0.707107
+      y: -0.0
+      z: 0.0
+    position:
+      x: 0.0
+      y: 0.0
+      z: 0.0
+  joint_numbers:
+  - 0
+  - 1
+  - 2
+  - 3
+  - 4
+  - 5
+  kin_chain_identifier: robot_arm
+joint_info:
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: shoulder_pan_joint
+  joint_limits:
+    effort: 150.0
+    lower: -6.283185
+    upper: 6.283185
+    velocity: 3.141593
+    acceleration: 10
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: shoulder_lift_joint
+  joint_limits:
+    effort: 150.0
+    lower: -6.283185
+    upper: 6.283185
+    velocity: 3.141593
+    acceleration: 10
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: elbow_joint
+  joint_limits:
+    effort: 150.0
+    lower: -3.141593
+    upper: 3.141593
+    velocity: 3.141593
+    acceleration: 10
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: wrist_1_joint
+  joint_limits:
+    effort: 28.0
+    lower: -6.283185
+    upper: 6.283185
+    velocity: 3.141593
+    acceleration: 10
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: wrist_2_joint
+  joint_limits:
+    effort: 28.0
+    lower: -6.283185
+    upper: 6.283185
+    velocity: 3.141593
+    acceleration: 10
+  joint_type: revolute
+  passive: false
+- default_effort_units: newton_meter
+  default_units: radian
+  joint_identifier: wrist_3_joint
+  joint_limits:
+    effort: 28.0
+    lower: -6.283185
+    upper: 6.283185
+    velocity: 3.141593
+    acceleration: 10
+  joint_type: revolute
+  passive: false
+


### PR DESCRIPTION
Adds the tesseract.py module to general_robotics_toolbox. This module contains the `TesseractRobot` class that can convert a `Robot` structure to a Tesseract environment that has accelerated kinematics functions. Supported functions include fwdkin(), invkin(), and jacobian(). Supported inverse kinematics algorithms include KDLInvKinChainLMA, KDLInvKinChainNR, OPWInvKin, and URInvKin. OPWInvKin is the solver for standard 6 axis industrial robots with spherical wrists.

Run

```
python -m pip install tesseract-robotics
```

to install Tesseract support.