### PR TITLE
Fix numpy warning in rox.hat() function

### DIFF
--- a/src/general_robotics_toolbox/general_robotics_toolbox.py
+++ b/src/general_robotics_toolbox/general_robotics_toolbox.py
@@ -49,12 +49,13 @@ def hat(k):
     """
     
     khat=np.zeros((3,3))
-    khat[0,1]=-k[2]
-    khat[0,2]=k[1]
-    khat[1,0]=k[2]
-    khat[1,2]=-k[0]
-    khat[2,0]=-k[1]
-    khat[2,1]=k[0]    
+    k_np = np.reshape(k, (3,))
+    khat[0,1]=-k_np[2]
+    khat[0,2]=k_np[1]
+    khat[1,0]=k_np[2]
+    khat[1,2]=-k_np[0]
+    khat[2,0]=-k_np[1]
+    khat[2,1]=k_np[0]
     return khat
 
 def invhat(khat):


### PR DESCRIPTION
Fix numpy warning in `general_robotics_toolbox.rox()` function caused by assigning a array to a scalar.

```
  /opt/hostedtoolcache/Python/3.13.11/x64/lib/python3.13/site-packages/general_robotics_toolbox/general_robotics_toolbox.py:52: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    khat[0,1]=-k[2]

test/test_general_robotics_toolbox.py: 529908 warnings
  /opt/hostedtoolcache/Python/3.13.11/x64/lib/python3.13/site-packages/general_robotics_toolbox/general_robotics_toolbox.py:53: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    khat[0,2]=k[1]

test/test_general_robotics_toolbox.py: 529908 warnings
  /opt/hostedtoolcache/Python/3.13.11/x64/lib/python3.13/site-packages/general_robotics_toolbox/general_robotics_toolbox.py:54: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    khat[1,0]=k[2]

test/test_general_robotics_toolbox.py: 529908 warnings
  /opt/hostedtoolcache/Python/3.13.11/x64/lib/python3.13/site-packages/general_robotics_toolbox/general_robotics_toolbox.py:55: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    khat[1,2]=-k[0]

test/test_general_robotics_toolbox.py: 529908 warnings
  /opt/hostedtoolcache/Python/3.13.11/x64/lib/python3.13/site-packages/general_robotics_toolbox/general_robotics_toolbox.py:56: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    khat[2,0]=-k[1]

test/test_general_robotics_toolbox.py: 529908 warnings
  /opt/hostedtoolcache/Python/3.13.11/x64/lib/python3.13/site-packages/general_robotics_toolbox/general_robotics_toolbox.py:57: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    khat[2,1]=k[0]
```